### PR TITLE
feat(sdk): use uuid to avoid ignored transactions

### DIFF
--- a/src/hubextensions.hub.test.ts
+++ b/src/hubextensions.hub.test.ts
@@ -38,7 +38,7 @@ describe('hubextensions', () => {
     await Sentry.flush(1000);
 
     expect(startProfilingSpy).toHaveBeenCalledTimes(1);
-    expect(stopProfilingSpy).toHaveBeenCalledWith('profile_hub', 0);
+    expect((stopProfilingSpy.mock.lastCall?.[0] as string).startsWith('profile_hub')).toBe(true);
     // One for profile, the other for transaction
     expect(transportSpy).toHaveBeenCalledTimes(2);
     expect(transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[0]).toMatchObject({ type: 'profile' });
@@ -54,12 +54,12 @@ describe('hubextensions', () => {
       throw new Error('Sentry getCurrentHub()->getClient()->getTransport() did not return a transport');
     }
 
-    const transaction = Sentry.getCurrentHub().startTransaction({ name: 'profile_hub' });
+    const transaction = Sentry.getCurrentHub().startTransaction({ name: 'timeout_transaction' });
     expect(startProfilingSpy).toHaveBeenCalledTimes(1);
     jest.advanceTimersByTime(30001);
 
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
-    expect(stopProfilingSpy).toHaveBeenCalledWith('profile_hub', 0);
+    expect((stopProfilingSpy.mock.lastCall?.[0] as string).startsWith('timeout_transaction')).toBe(true);
 
     transaction.finish();
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -69,7 +69,7 @@ describe('Sentry - Profiling', () => {
     expect(findProfile(STATIC_TRANSPORT.send)).not.toBe(null);
   });
 
-  it('discards overlapping transaction with same title', async () => {
+  it('does not discard overlapping transaction with same title', async () => {
     const t1 = Sentry.startTransaction({ name: 'same-title' });
     const t2 = Sentry.startTransaction({ name: 'same-title' });
     await wait(100);
@@ -77,7 +77,7 @@ describe('Sentry - Profiling', () => {
     t1.finish();
 
     await Sentry.flush();
-    expect(findAllProfiles(STATIC_TRANSPORT.send)).toHaveLength(1);
+    expect(findAllProfiles(STATIC_TRANSPORT.send)).toHaveLength(2);
     expect(findProfile(STATIC_TRANSPORT.send)).not.toBe(null);
   });
 


### PR DESCRIPTION
Concurrent transactions with same name were previously silently ignored (default v8 profiler behavior). 

This PR adds a uuid to the transaction name when calling stopProfiling/startProfiling to mitigate that. This is internal and will not show up in the final profile.