### PR TITLE
feat(profile): log call site info

### DIFF
--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -211,7 +211,7 @@ static void StartProfiling(const v8::FunctionCallbackInfo<v8::Value>& args) {
     Local<String> title = Nan::To<String>(args[0]).ToLocalChecked();
 
     v8::CpuProfilingOptions options = v8::CpuProfilingOptions{ 
-      v8::CpuProfilingMode::kLeafNodeLineNumbers, CpuProfilingOptions::kNoSampleLimit, 
+      v8::CpuProfilingMode::kCallerLineNumbers, CpuProfilingOptions::kNoSampleLimit, 
       SAMPLING_INTERVAL_US };
 
     Profiler* profiler = reinterpret_cast<Profiler*>(args.Data().As<External>()->Value());


### PR DESCRIPTION
Log call site info instead of the function definition.

```
// Comparing results from main and 7aed418 (sizes in B)
sampled: 44269.5 (+13.18%)
cpu_profiler.sampled.json.gz: 2691 (-1.68%)
cpu_profiler.sampled.json.br: 1929 (-0.98%)
cpu_profiler.sampled.json.zst: 2721 (-0.37%)
```
