### PR TITLE
ref(benchmark): add jest benchmark

### DIFF
--- a/benchmarks/integrations/jest/js/base/base.config.js
+++ b/benchmarks/integrations/jest/js/base/base.config.js
@@ -1,0 +1,5 @@
+const config = {
+  testMatch: ['<rootDir>/base.test.js']
+};
+
+module.exports = config;

--- a/benchmarks/integrations/jest/js/base/base.env.js
+++ b/benchmarks/integrations/jest/js/base/base.env.js
@@ -1,0 +1,271 @@
+const Sentry = require('@sentry/node');
+require('@sentry/tracing');
+
+function isNotTransaction(span) {
+  return span.op !== 'jest test';
+}
+
+function createEnvironment() {
+  const BaseEnvironment = require('jest-environment-node');
+
+  return class SentryEnvironment extends BaseEnvironment {
+    constructor(...args) {
+      super(...args);
+
+      const [config, context] = args;
+
+      this.Sentry = Sentry;
+      // Add profiling integration
+
+      this.Sentry.init({
+        debug: true,
+        dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+        tracesSampleRate: 1
+      });
+
+      this.testPath = context.testPath.replace(process.cwd(), '');
+
+      this.runDescribe = new Map();
+      this.testContainers = new Map();
+      this.tests = new Map();
+      this.hooks = new Map();
+    }
+
+    async setup() {
+      if (!this.Sentry || !this.options) {
+        await super.setup();
+        return;
+      }
+
+      const { transactionOptions } = this.options;
+
+      this.transaction = this.Sentry.startTransaction({
+        op: 'jest test suite',
+        description: this.testPath,
+        name: this.testPath,
+        tags: transactionOptions.tags
+      });
+      this.global.transaction = this.transaction;
+      this.global.Sentry = this.Sentry;
+
+      this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
+
+      const span = this.transaction.startChild({
+        op: 'setup',
+        description: this.testPath
+      });
+      await super.setup();
+      span.finish();
+    }
+
+    async teardown() {
+      const span = this.transaction.startChild({
+        op: 'teardown',
+        description: this.testPath
+      });
+      await super.teardown();
+      span.finish();
+      if (this.transaction) {
+        this.transaction.finish();
+      }
+    }
+
+    getVmContext() {
+      if (this.transaction && !this.getVmContextSpan) {
+        this.getVmContextSpan = this.transaction.startChild({
+          op: 'getVmContext'
+        });
+      }
+      return super.getVmContext();
+    }
+
+    getName(parent) {
+      if (!parent) {
+        return '';
+      }
+
+      // Ignore these for now as it adds a level of nesting and I'm not quite sure where it's even coming from
+      if (parent.name === 'ROOT_DESCRIBE_BLOCK') {
+        return '';
+      }
+
+      const parentName = this.getName(parent.parent);
+      return `${parentName ? `${parentName} >` : ''} ${parent.name}`;
+    }
+
+    getData({ name, ...event }) {
+      switch (name) {
+        case 'run_describe_start':
+        case 'run_describe_finish':
+          if (this.getVmContextSpan) {
+            this.getVmContextSpan.finish();
+            this.getVmContextSpan = null;
+          }
+
+          return {
+            op: 'describe',
+            obj: event.describeBlock,
+            parentObj: event.describeBlock.parent,
+            dataStore: this.runDescribe,
+            parentStore: this.runDescribe
+          };
+
+        case 'test_start':
+        case 'test_done':
+          return {
+            op: 'test',
+            obj: event.test,
+            parentObj: event.test.parent,
+            dataStore: this.testContainers,
+            parentStore: this.runDescribe,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'test_fn_start':
+        case 'test_fn_success':
+        case 'test_fn_failure':
+          return {
+            op: 'test-fn',
+            obj: event.test,
+            parentObj: event.test,
+            dataStore: this.tests,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'hook_start':
+          return {
+            obj: event.hook.parent,
+            op: event.hook.type,
+            dataStore: this.hooks
+          };
+
+        case 'hook_success':
+        case 'hook_failure':
+          return {
+            obj: event.hook.parent,
+            parentObj: event.test && event.test.parent,
+            dataStore: this.hooks,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              const parent = this.testContainers.get(this.getName(event.test));
+              if (parent && !Array.isArray(parent)) {
+                return parent.startChild(span);
+              } else if (Array.isArray(parent)) {
+                return parent.find(isNotTransaction).startChild(span);
+              }
+              return span;
+            }
+          };
+
+        case 'start_describe_definition':
+        case 'finish_describe_definition':
+        case 'add_test':
+        case 'add_hook':
+        case 'run_start':
+        case 'run_finish':
+        case 'test_todo':
+        case 'setup':
+        case 'teardown':
+          return null;
+
+        default:
+          return null;
+      }
+    }
+
+    handleTestEvent(event) {
+      if (!this.Sentry) {
+        return;
+      }
+
+      const data = this.getData(event);
+      const { name } = event;
+
+      if (!data) {
+        return;
+      }
+
+      const { obj, parentObj, dataStore, parentStore, op, beforeFinish } = data;
+      const testName = this.getName(obj);
+
+      if (name.includes('start')) {
+        // Make this an option maybe
+        if (!testName) {
+          return;
+        }
+
+        const spans = [];
+        const parentName = parentObj && this.getName(parentObj);
+        const spanProps = { op, description: testName };
+        const span =
+          parentObj && parentStore.has(parentName)
+            ? Array.isArray(parentStore.get(parentName))
+              ? parentStore.get(parentName).map((s) => s.startChild(spanProps))
+              : [parentStore.get(parentName).startChild(spanProps)]
+            : [this.transaction.startChild(spanProps)];
+
+        // @ts-ignore this could be undefined, but we dont care
+        spans.push(...span);
+
+        // If we are starting a test, let's also make it a transaction so we can see our slowest tests
+        if (spanProps.op === 'test') {
+          const testTransaction = this.Sentry.startTransaction({
+            ...spanProps,
+            op: 'jest test',
+            name: spanProps.description,
+            description: null,
+            // attach the trace id and span id of parent transaction so they're part of the same trace
+            parentSpanId: span[0].spanId,
+            traceId: span[0].transaction.traceId,
+            tags: this.options.transactionOptions?.tags
+          });
+          // @ts-ignore this could be undefined, but we dont care
+          spans.push(testTransaction);
+
+          // ensure that the test transaction is on the scope while it's happening
+          this.Sentry.configureScope((scope) => scope.setSpan(testTransaction));
+        }
+
+        dataStore.set(testName, spans);
+
+        return;
+      }
+
+      if (dataStore.has(testName)) {
+        const spans = dataStore.get(testName);
+
+        if (name.includes('failure')) {
+          if (event.error) {
+            this.Sentry.captureException(event.error);
+          }
+        }
+
+        spans.forEach((span) => {
+          if (beforeFinish) {
+            span = beforeFinish(span);
+            if (!span) {
+              throw new Error('`beforeFinish()` needs to return a span');
+            }
+          }
+
+          span.finish();
+
+          // if this is finishing a jest test span, then put the test suite transaction
+          // back on the scope
+          if (span.op === 'jest test') {
+            this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
+          }
+        });
+      }
+    }
+  };
+}
+
+module.exports = createEnvironment;

--- a/benchmarks/integrations/jest/js/base/base.test.js
+++ b/benchmarks/integrations/jest/js/base/base.test.js
@@ -1,0 +1,9 @@
+describe('benchmark', () => {
+  // @ts-ignore dont care about definition
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  it('base env', async () => {
+    await wait(1000);
+    expect(1).toBe(1);
+  });
+});

--- a/benchmarks/integrations/jest/js/base/run.js
+++ b/benchmarks/integrations/jest/js/base/run.js
@@ -1,0 +1,22 @@
+// jest --config benchmarks/integrations/jest/profiled/profiled.config.ts --detectOpenHandles && jest --config benchmarks/integrations/jest/base/base.config.ts
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+  throw err;
+});
+
+// eslint-disable-next-line jest/no-jest-import
+const jest = require('jest');
+
+jest.run([
+  '--config',
+  'benchmarks/integrations/jest/js/base/base.config.js',
+  '--no-cache',
+  '--no-watchman',
+  '--no-watch',
+  '--runInBand',
+  '--silent',
+  'benchmarks/integrations/jest/js/base/base.test.js'
+]);

--- a/benchmarks/integrations/jest/js/profiled/profiled.config.js
+++ b/benchmarks/integrations/jest/js/profiled/profiled.config.js
@@ -1,0 +1,6 @@
+const config = {
+  testMatch: ['<rootDir>/profiled.test.js'],
+  testEnvironment: '<rootDir>/profiled.env.js'
+};
+
+module.exports = config;

--- a/benchmarks/integrations/jest/js/profiled/profiled.env.js
+++ b/benchmarks/integrations/jest/js/profiled/profiled.env.js
@@ -1,0 +1,226 @@
+const Sentry = require('@sentry/node');
+require('@sentry/tracing');
+const { ProfilingIntegration } = require('./../../../../../lib/');
+
+function isNotTransaction(span) {
+  return span.op !== 'jest test';
+}
+
+function createProfiledEnvironmentEnvironment() {
+  const BaseEnvironment = require('jest-environment-node').default;
+
+  return class SentryEnvironment extends BaseEnvironment {
+    constructor(...args) {
+      super(...args);
+
+      const [config, context] = args;
+
+      this.Sentry = Sentry;
+      this.Sentry.init({
+        debug: true,
+        dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+        integrations: [new ProfilingIntegration()],
+        tracesSampleRate: 1,
+        profilesSampleRate: 1
+      });
+
+      this.testPath = context.testPath.replace(process.cwd(), '');
+
+      this.runDescribe = new Map();
+      this.testContainers = new Map();
+      this.tests = new Map();
+      this.hooks = new Map();
+    }
+
+    async setup() {
+      if (!this.Sentry || !this.options) {
+        await super.setup();
+        return;
+      }
+
+      this.transaction = this.Sentry.startTransaction({
+        op: 'jest test suite',
+        description: this.testPath,
+        name: this.testPath
+      });
+
+      this.global.transaction = this.transaction;
+      this.global.Sentry = this.Sentry;
+
+      this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
+
+      const span = this.transaction.startChild({
+        op: 'setup',
+        description: this.testPath
+      });
+      await super.setup();
+      span.finish();
+    }
+
+    async teardown() {
+      if (this.transaction) {
+        const span = this.transaction.startChild({
+          op: 'teardown',
+          description: this.testPath
+        });
+        await super.teardown();
+        span.finish();
+      }
+      if (this.transaction) {
+        this.transaction.finish();
+      }
+    }
+
+    getVmContext() {
+      if (this.transaction && !this.getVmContextSpan) {
+        this.getVmContextSpan = this.transaction.startChild({
+          op: 'getVmContext'
+        });
+      }
+      return super.getVmContext();
+    }
+
+    getName(parent) {
+      if (!parent) {
+        return '';
+      }
+
+      // Ignore these for now as it adds a level of nesting and I'm not quite sure where it's even coming from
+      if (parent.name === 'ROOT_DESCRIBE_BLOCK') {
+        return '';
+      }
+
+      const parentName = this.getName(parent.parent);
+      return `${parentName ? `${parentName} >` : ''} ${parent.name}`;
+    }
+
+    getData({ name, ...event }) {
+      switch (name) {
+        case 'run_describe_start':
+        case 'run_describe_finish':
+          if (this.getVmContextSpan) {
+            this.getVmContextSpan.finish();
+            this.getVmContextSpan = null;
+          }
+
+          return {
+            op: 'describe',
+            obj: event.describeBlock,
+            parentObj: event.describeBlock.parent,
+            dataStore: this.runDescribe,
+            parentStore: this.runDescribe
+          };
+
+        case 'test_start':
+        case 'test_done':
+          return {
+            op: 'test',
+            obj: event.test,
+            parentObj: event.test.parent,
+            dataStore: this.testContainers,
+            parentStore: this.runDescribe,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'test_fn_start':
+        case 'test_fn_success':
+        case 'test_fn_failure':
+          return {
+            op: 'test-fn',
+            obj: event.test,
+            parentObj: event.test,
+            dataStore: this.tests,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'hook_start':
+          return {
+            obj: event.hook.parent,
+            op: event.hook.type,
+            dataStore: this.hooks
+          };
+
+        case 'hook_success':
+        case 'hook_failure':
+          return {
+            obj: event.hook.parent,
+            parentObj: event.test && event.test.parent,
+            dataStore: this.hooks,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              const parent = this.testContainers.get(this.getName(event.test));
+              if (parent && !Array.isArray(parent)) {
+                return parent.startChild(span);
+              } else if (Array.isArray(parent)) {
+                return parent.find(isNotTransaction).startChild(span);
+              }
+              return span;
+            }
+          };
+
+        case 'start_describe_definition':
+        case 'finish_describe_definition':
+        case 'add_test':
+        case 'add_hook':
+        case 'run_start':
+        case 'run_finish':
+        case 'test_todo':
+        case 'setup':
+        case 'teardown':
+          return null;
+
+        default:
+          return null;
+      }
+    }
+
+    handleTestEvent(event) {
+      if (!this.Sentry) {
+        return;
+      }
+
+      const data = this.getData(event);
+      const { name } = event;
+
+      if (!data) {
+        return;
+      }
+
+      const { obj, op, dataStore, beforeFinish } = data;
+      const testName = this.getName(obj);
+
+      if (name.includes('start') && op === 'test') {
+        // Make this an option maybe
+        if (!testName) {
+          return;
+        }
+
+        // If we are starting a test, let's also make it a transaction so we can see our slowest tests
+        const testTransaction = this.Sentry.startTransaction({
+          name: testName,
+          op: 'jest test'
+        });
+
+        // ensure that the test transaction is on the scope while it's happening
+
+        dataStore.set(testName, testTransaction);
+        return;
+      }
+
+      if (dataStore.has(testName) && beforeFinish) {
+        const transaction = dataStore.get(testName);
+        const testTransaction = beforeFinish(transaction);
+        testTransaction.finish();
+      }
+    }
+  };
+}
+
+module.exports = createProfiledEnvironmentEnvironment();

--- a/benchmarks/integrations/jest/js/profiled/profiled.test.js
+++ b/benchmarks/integrations/jest/js/profiled/profiled.test.js
@@ -1,0 +1,7 @@
+describe('benchmark', () => {
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  it('profiled-env', async () => {
+    await wait(1000);
+    expect(1).toBe(1);
+  });
+});

--- a/benchmarks/integrations/jest/js/profiled/run.js
+++ b/benchmarks/integrations/jest/js/profiled/run.js
@@ -1,0 +1,22 @@
+// jest --config benchmarks/integrations/jest/js/profiled/profiled.config.js --detectOpenHandles && jest --config benchmarks/integrations/jest/js/base/base.config.js
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+  throw err;
+});
+
+// eslint-disable-next-line jest/no-jest-import
+const jest = require('jest');
+
+jest.run([
+  '--config',
+  'benchmarks/integrations/jest/js/profiled/profiled.config.js',
+  '--no-cache',
+  '--no-watchman',
+  '--no-watch',
+  '--runInBand',
+  '--silent',
+  'benchmarks/integrations/jest/js/profiled/profiled.test.js'
+]);

--- a/benchmarks/integrations/jest/ts/base/base.config.ts
+++ b/benchmarks/integrations/jest/ts/base/base.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  testMatch: ['<rootDir>/base.test.ts']
+};
+
+export default config;

--- a/benchmarks/integrations/jest/ts/base/base.env.ts
+++ b/benchmarks/integrations/jest/ts/base/base.env.ts
@@ -1,0 +1,271 @@
+const Sentry = require('@sentry/node');
+require('@sentry/tracing');
+
+function isNotTransaction(span) {
+  return span.op !== 'jest test';
+}
+
+function createEnvironment() {
+  const BaseEnvironment = require('jest-environment-node');
+
+  return class SentryEnvironment extends BaseEnvironment {
+    constructor(...args) {
+      super(...args);
+
+      const [config, context] = args;
+
+      this.Sentry = Sentry;
+      // Add profiling integration
+
+      this.Sentry.init({
+        debug: true,
+        dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+        tracesSampleRate: 1
+      });
+
+      this.testPath = context.testPath.replace(process.cwd(), '');
+
+      this.runDescribe = new Map();
+      this.testContainers = new Map();
+      this.tests = new Map();
+      this.hooks = new Map();
+    }
+
+    async setup() {
+      if (!this.Sentry || !this.options) {
+        await super.setup();
+        return;
+      }
+
+      const { transactionOptions } = this.options;
+
+      this.transaction = this.Sentry.startTransaction({
+        op: 'jest test suite',
+        description: this.testPath,
+        name: this.testPath,
+        tags: transactionOptions.tags
+      });
+      this.global.transaction = this.transaction;
+      this.global.Sentry = this.Sentry;
+
+      this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
+
+      const span = this.transaction.startChild({
+        op: 'setup',
+        description: this.testPath
+      });
+      await super.setup();
+      span.finish();
+    }
+
+    async teardown() {
+      const span = this.transaction.startChild({
+        op: 'teardown',
+        description: this.testPath
+      });
+      await super.teardown();
+      span.finish();
+      if (this.transaction) {
+        this.transaction.finish();
+      }
+    }
+
+    getVmContext() {
+      if (this.transaction && !this.getVmContextSpan) {
+        this.getVmContextSpan = this.transaction.startChild({
+          op: 'getVmContext'
+        });
+      }
+      return super.getVmContext();
+    }
+
+    getName(parent) {
+      if (!parent) {
+        return '';
+      }
+
+      // Ignore these for now as it adds a level of nesting and I'm not quite sure where it's even coming from
+      if (parent.name === 'ROOT_DESCRIBE_BLOCK') {
+        return '';
+      }
+
+      const parentName = this.getName(parent.parent);
+      return `${parentName ? `${parentName} >` : ''} ${parent.name}`;
+    }
+
+    getData({ name, ...event }) {
+      switch (name) {
+        case 'run_describe_start':
+        case 'run_describe_finish':
+          if (this.getVmContextSpan) {
+            this.getVmContextSpan.finish();
+            this.getVmContextSpan = null;
+          }
+
+          return {
+            op: 'describe',
+            obj: event.describeBlock,
+            parentObj: event.describeBlock.parent,
+            dataStore: this.runDescribe,
+            parentStore: this.runDescribe
+          };
+
+        case 'test_start':
+        case 'test_done':
+          return {
+            op: 'test',
+            obj: event.test,
+            parentObj: event.test.parent,
+            dataStore: this.testContainers,
+            parentStore: this.runDescribe,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'test_fn_start':
+        case 'test_fn_success':
+        case 'test_fn_failure':
+          return {
+            op: 'test-fn',
+            obj: event.test,
+            parentObj: event.test,
+            dataStore: this.tests,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'hook_start':
+          return {
+            obj: event.hook.parent,
+            op: event.hook.type,
+            dataStore: this.hooks
+          };
+
+        case 'hook_success':
+        case 'hook_failure':
+          return {
+            obj: event.hook.parent,
+            parentObj: event.test && event.test.parent,
+            dataStore: this.hooks,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              const parent = this.testContainers.get(this.getName(event.test));
+              if (parent && !Array.isArray(parent)) {
+                return parent.startChild(span);
+              } else if (Array.isArray(parent)) {
+                return parent.find(isNotTransaction).startChild(span);
+              }
+              return span;
+            }
+          };
+
+        case 'start_describe_definition':
+        case 'finish_describe_definition':
+        case 'add_test':
+        case 'add_hook':
+        case 'run_start':
+        case 'run_finish':
+        case 'test_todo':
+        case 'setup':
+        case 'teardown':
+          return null;
+
+        default:
+          return null;
+      }
+    }
+
+    handleTestEvent(event) {
+      if (!this.Sentry) {
+        return;
+      }
+
+      const data = this.getData(event);
+      const { name } = event;
+
+      if (!data) {
+        return;
+      }
+
+      const { obj, parentObj, dataStore, parentStore, op, beforeFinish } = data;
+      const testName = this.getName(obj);
+
+      if (name.includes('start')) {
+        // Make this an option maybe
+        if (!testName) {
+          return;
+        }
+
+        const spans = [];
+        const parentName = parentObj && this.getName(parentObj);
+        const spanProps = { op, description: testName };
+        const span =
+          parentObj && parentStore.has(parentName)
+            ? Array.isArray(parentStore.get(parentName))
+              ? parentStore.get(parentName).map((s) => s.startChild(spanProps))
+              : [parentStore.get(parentName).startChild(spanProps)]
+            : [this.transaction.startChild(spanProps)];
+
+        // @ts-ignore this could be undefined, but we dont care
+        spans.push(...span);
+
+        // If we are starting a test, let's also make it a transaction so we can see our slowest tests
+        if (spanProps.op === 'test') {
+          const testTransaction = this.Sentry.startTransaction({
+            ...spanProps,
+            op: 'jest test',
+            name: spanProps.description,
+            description: null,
+            // attach the trace id and span id of parent transaction so they're part of the same trace
+            parentSpanId: span[0].spanId,
+            traceId: span[0].transaction.traceId,
+            tags: this.options.transactionOptions?.tags
+          });
+          // @ts-ignore this could be undefined, but we dont care
+          spans.push(testTransaction);
+
+          // ensure that the test transaction is on the scope while it's happening
+          this.Sentry.configureScope((scope) => scope.setSpan(testTransaction));
+        }
+
+        dataStore.set(testName, spans);
+
+        return;
+      }
+
+      if (dataStore.has(testName)) {
+        const spans = dataStore.get(testName);
+
+        if (name.includes('failure')) {
+          if (event.error) {
+            this.Sentry.captureException(event.error);
+          }
+        }
+
+        spans.forEach((span) => {
+          if (beforeFinish) {
+            span = beforeFinish(span);
+            if (!span) {
+              throw new Error('`beforeFinish()` needs to return a span');
+            }
+          }
+
+          span.finish();
+
+          // if this is finishing a jest test span, then put the test suite transaction
+          // back on the scope
+          if (span.op === 'jest test') {
+            this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
+          }
+        });
+      }
+    }
+  };
+}
+
+module.exports = createEnvironment;

--- a/benchmarks/integrations/jest/ts/base/base.test.ts
+++ b/benchmarks/integrations/jest/ts/base/base.test.ts
@@ -1,0 +1,9 @@
+describe('benchmark', () => {
+  // @ts-ignore dont care about definition
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  it('base env', async () => {
+    await wait(1000);
+    expect(1).toBe(1);
+  });
+});

--- a/benchmarks/integrations/jest/ts/base/run.js
+++ b/benchmarks/integrations/jest/ts/base/run.js
@@ -1,0 +1,22 @@
+// jest --config benchmarks/integrations/jest/ts/profiled/profiled.config.ts --detectOpenHandles && jest --config benchmarks/integrations/jest/ts/base/base.config.ts
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+  throw err;
+});
+
+// eslint-disable-next-line jest/no-jest-import
+const jest = require('jest');
+
+jest.run([
+  '--config',
+  'benchmarks/integrations/jest/ts/base/base.config.ts',
+  '--no-cache',
+  '--no-watchman',
+  '--no-watch',
+  '--runInBand',
+  '--silent',
+  'benchmarks/integrations/jest/ts/base/base.test.ts'
+]);

--- a/benchmarks/integrations/jest/ts/profiled/profiled.config.ts
+++ b/benchmarks/integrations/jest/ts/profiled/profiled.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  testMatch: ['<rootDir>/profiled.test.ts'],
+  testEnvironment: '<rootDir>/profiled.env.ts'
+};
+
+export default config;

--- a/benchmarks/integrations/jest/ts/profiled/profiled.env.ts
+++ b/benchmarks/integrations/jest/ts/profiled/profiled.env.ts
@@ -1,0 +1,226 @@
+const Sentry = require('@sentry/node');
+require('@sentry/tracing');
+const { ProfilingIntegration } = require('./../../../../../lib/');
+
+function isNotTransaction(span) {
+  return span.op !== 'jest test';
+}
+
+function createProfiledEnvironmentEnvironment() {
+  const BaseEnvironment = require('jest-environment-node').default;
+
+  return class SentryEnvironment extends BaseEnvironment {
+    constructor(...args) {
+      super(...args);
+
+      const [config, context] = args;
+
+      this.Sentry = Sentry;
+      this.Sentry.init({
+        debug: true,
+        dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+        integrations: [new ProfilingIntegration()],
+        tracesSampleRate: 1,
+        profilesSampleRate: 1
+      });
+
+      this.testPath = context.testPath.replace(process.cwd(), '');
+
+      this.runDescribe = new Map();
+      this.testContainers = new Map();
+      this.tests = new Map();
+      this.hooks = new Map();
+    }
+
+    async setup() {
+      if (!this.Sentry || !this.options) {
+        await super.setup();
+        return;
+      }
+
+      this.transaction = this.Sentry.startTransaction({
+        op: 'jest test suite',
+        description: this.testPath,
+        name: this.testPath
+      });
+
+      this.global.transaction = this.transaction;
+      this.global.Sentry = this.Sentry;
+
+      this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
+
+      const span = this.transaction.startChild({
+        op: 'setup',
+        description: this.testPath
+      });
+      await super.setup();
+      span.finish();
+    }
+
+    async teardown() {
+      if (this.transaction) {
+        const span = this.transaction.startChild({
+          op: 'teardown',
+          description: this.testPath
+        });
+        await super.teardown();
+        span.finish();
+      }
+      if (this.transaction) {
+        this.transaction.finish();
+      }
+    }
+
+    getVmContext() {
+      if (this.transaction && !this.getVmContextSpan) {
+        this.getVmContextSpan = this.transaction.startChild({
+          op: 'getVmContext'
+        });
+      }
+      return super.getVmContext();
+    }
+
+    getName(parent) {
+      if (!parent) {
+        return '';
+      }
+
+      // Ignore these for now as it adds a level of nesting and I'm not quite sure where it's even coming from
+      if (parent.name === 'ROOT_DESCRIBE_BLOCK') {
+        return '';
+      }
+
+      const parentName = this.getName(parent.parent);
+      return `${parentName ? `${parentName} >` : ''} ${parent.name}`;
+    }
+
+    getData({ name, ...event }) {
+      switch (name) {
+        case 'run_describe_start':
+        case 'run_describe_finish':
+          if (this.getVmContextSpan) {
+            this.getVmContextSpan.finish();
+            this.getVmContextSpan = null;
+          }
+
+          return {
+            op: 'describe',
+            obj: event.describeBlock,
+            parentObj: event.describeBlock.parent,
+            dataStore: this.runDescribe,
+            parentStore: this.runDescribe
+          };
+
+        case 'test_start':
+        case 'test_done':
+          return {
+            op: 'test',
+            obj: event.test,
+            parentObj: event.test.parent,
+            dataStore: this.testContainers,
+            parentStore: this.runDescribe,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'test_fn_start':
+        case 'test_fn_success':
+        case 'test_fn_failure':
+          return {
+            op: 'test-fn',
+            obj: event.test,
+            parentObj: event.test,
+            dataStore: this.tests,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              span.setStatus(!event.test.errors.length ? 'ok' : 'internal_error');
+              return span;
+            }
+          };
+
+        case 'hook_start':
+          return {
+            obj: event.hook.parent,
+            op: event.hook.type,
+            dataStore: this.hooks
+          };
+
+        case 'hook_success':
+        case 'hook_failure':
+          return {
+            obj: event.hook.parent,
+            parentObj: event.test && event.test.parent,
+            dataStore: this.hooks,
+            parentStore: this.testContainers,
+            beforeFinish: (span) => {
+              const parent = this.testContainers.get(this.getName(event.test));
+              if (parent && !Array.isArray(parent)) {
+                return parent.startChild(span);
+              } else if (Array.isArray(parent)) {
+                return parent.find(isNotTransaction).startChild(span);
+              }
+              return span;
+            }
+          };
+
+        case 'start_describe_definition':
+        case 'finish_describe_definition':
+        case 'add_test':
+        case 'add_hook':
+        case 'run_start':
+        case 'run_finish':
+        case 'test_todo':
+        case 'setup':
+        case 'teardown':
+          return null;
+
+        default:
+          return null;
+      }
+    }
+
+    handleTestEvent(event) {
+      if (!this.Sentry) {
+        return;
+      }
+
+      const data = this.getData(event);
+      const { name } = event;
+
+      if (!data) {
+        return;
+      }
+
+      const { obj, op, dataStore, beforeFinish } = data;
+      const testName = this.getName(obj);
+
+      if (name.includes('start') && op === 'test') {
+        // Make this an option maybe
+        if (!testName) {
+          return;
+        }
+
+        // If we are starting a test, let's also make it a transaction so we can see our slowest tests
+        const testTransaction = this.Sentry.startTransaction({
+          name: testName,
+          op: 'jest test'
+        });
+
+        // ensure that the test transaction is on the scope while it's happening
+
+        dataStore.set(testName, testTransaction);
+        return;
+      }
+
+      if (dataStore.has(testName) && beforeFinish) {
+        const transaction = dataStore.get(testName);
+        const testTransaction = beforeFinish(transaction);
+        testTransaction.finish();
+      }
+    }
+  };
+}
+
+module.exports = createProfiledEnvironmentEnvironment();

--- a/benchmarks/integrations/jest/ts/profiled/profiled.test.ts
+++ b/benchmarks/integrations/jest/ts/profiled/profiled.test.ts
@@ -1,0 +1,8 @@
+describe('benchmark', () => {
+  // @ts-ignore dont care about definition
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  it('profiled-env', async () => {
+    await wait(1000);
+    expect(1).toBe(1);
+  });
+});

--- a/benchmarks/integrations/jest/ts/profiled/run.js
+++ b/benchmarks/integrations/jest/ts/profiled/run.js
@@ -1,0 +1,22 @@
+// jest --config benchmarks/integrations/jest/ts/profiled/profiled.config.ts --detectOpenHandles && jest --config benchmarks/integrations/jest/ts/base/base.config.ts
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+  throw err;
+});
+
+// eslint-disable-next-line jest/no-jest-import
+const jest = require('jest');
+
+jest.run([
+  '--config',
+  'benchmarks/integrations/jest/profiled/profiled.config.ts',
+  '--no-cache',
+  '--no-watchman',
+  '--no-watch',
+  '--runInBand',
+  '--silent',
+  'benchmarks/integrations/jest/profiled/profiled.test.ts'
+]);


### PR DESCRIPTION
We are currently incurring significant overhead in jest tests (30% added time when running on gha), see https://github.com/getsentry/sentry/pull/40183. This adds a reproducible env where we can run benchmarks on a profiled and non profiled env so we can eliminate causes faster.