### PR TITLE
ref(sdk): add temporary spans

### DIFF
--- a/src/hubextensions.test.ts
+++ b/src/hubextensions.test.ts
@@ -9,6 +9,7 @@ function makeTransactionMock(): Transaction {
   return {
     metadata: {},
     tags: {},
+    startChild: () => ({ finish: () => void 0 }),
     finish() {
       return;
     },

--- a/src/hubextensions.ts
+++ b/src/hubextensions.ts
@@ -50,6 +50,7 @@ export function __PRIVATE__wrapStartTransactionWithProfiling(startTransaction: S
 
     // We need to reference the original finish call to avoid creating an infinite loop
     const originalFinish = transaction.finish.bind(transaction);
+    // @TODO remove this
     const start = transaction.startChild({
       op: 'sentry.startProfiling'
     });
@@ -78,6 +79,7 @@ export function __PRIVATE__wrapStartTransactionWithProfiling(startTransaction: S
         return profile;
       }
 
+      // @TODO remove this
       const stop = transaction.startChild({
         op: 'sentry.stopProfiling'
       });


### PR DESCRIPTION
We are seeing some delays between stopProfiling and transaction.finish. Add temporary spans so we can see if this is a performance penalty from calling to c++ code.