### PR TITLE
fix(profile): wrong stack indexing insertion

### DIFF
--- a/src/hubextensions.test.ts
+++ b/src/hubextensions.test.ts
@@ -85,7 +85,6 @@ describe('hubextensions', () => {
     expect(transaction.metadata?.profile).toBeUndefined();
   });
   it('starts the profiler', () => {
-    jest.unmock('./../build/Release/sentry_cpu_profiler');
     const startProfilingSpy = jest.spyOn(profiler, 'startProfiling');
     const stopProfilingSpy = jest.spyOn(profiler, 'stopProfiling');
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,7 @@ export interface Profile {
       image_vmaddr: string;
     }[];
   };
-  transactions?: {
+  transactions: {
     name: string;
     trace_id: string;
     id: string;
@@ -179,7 +179,7 @@ export function createProfilingEventEnvelope(
     release: event.sdk?.version || 'unknown',
     runtime: {
       name: 'node',
-      version: process.versions.node
+      version: process.versions.node || 'unknown'
     },
     os: {
       name: PLATFORM,
@@ -190,7 +190,6 @@ export function createProfilingEventEnvelope(
       locale:
         (process.env['LC_ALL'] || process.env['LC_MESSAGES'] || process.env['LANG'] || process.env['LANGUAGE']) ??
         'unknown locale',
-      // os.machine is new in node18
       model: MODEL,
       manufacturer: TYPE,
       architecture: ARCH,


### PR DESCRIPTION
When deduping stack frames I introduced a bug that would result in the final stacks array to contain holes.

Added a test that reproduces the behavior and fixed the insertion index problem.