### PR TITLE
feat(trace_id): provide fallback for trace_id

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,6 +170,7 @@ export function createProfilingEventEnvelope(
   const enrichedThreadProfile = enrichWithThreadInformation(rawProfile);
   const transactionStartMs = typeof event.start_timestamp === 'number' ? event.start_timestamp * 1000 : Date.now();
   const transactionEndMs = typeof event.timestamp === 'number' ? event.timestamp * 1000 : Date.now();
+  const maybeTraceId = event.contexts?.['trace']?.['trace_id'];
 
   const profile: Profile = {
     event_id: uuid4(),
@@ -200,7 +201,7 @@ export function createProfilingEventEnvelope(
       {
         name: event.transaction || '',
         id: event.event_id || uuid4(),
-        trace_id: (event?.contexts?.['trace']?.['trace_id'] as string) ?? '',
+        trace_id: typeof maybeTraceId === 'string' && maybeTraceId.length > 0 ? maybeTraceId : uuid4(),
         active_thread_id: THREAD_ID_STRING,
         relative_start_ns: '0',
         relative_end_ns: ((transactionEndMs - transactionStartMs) * 1e6).toFixed(0)


### PR DESCRIPTION
It seems this might be failing validation if trace_id is not set on the transaction. Tbc by @phacops if empty string fails here