### PR TITLE
test(build): add node 19 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-2019, ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
         target: [x64]
         host: [x64]
         # arm64 is not supported by gh runners yet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-2019, ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -279,12 +279,10 @@ static void StartProfiling(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
   v8::Local<v8::String> title = Nan::To<v8::String>(args[0]).ToLocalChecked();
 
-  v8::CpuProfilingOptions options = v8::CpuProfilingOptions{
-    v8::CpuProfilingMode::kCallerLineNumbers, v8::CpuProfilingOptions::kNoSampleLimit,
-    SAMPLING_INTERVAL_US };
-
   Profiler* profiler = reinterpret_cast<Profiler*>(args.Data().As<v8::External>()->Value());
-  profiler->cpu_profiler->StartProfiling(title, options);
+  profiler->cpu_profiler->StartProfiling(title, {
+    v8::CpuProfilingMode::kCallerLineNumbers, v8::CpuProfilingOptions::kNoSampleLimit,
+    SAMPLING_INTERVAL_US });
 };
 
 // StopProfiling(string title)

--- a/src/cpu_profiler.ts
+++ b/src/cpu_profiler.ts
@@ -56,7 +56,6 @@ interface V8CpuProfilerBindings {
   stopProfiling(name: string): RawThreadCpuProfile | null;
 }
 
-console.log(projectRootDirectory);
 const privateBindings: PrivateV8CpuProfilerBindings = importCppBindingsModule();
 const CpuProfilerBindings: V8CpuProfilerBindings = {
   startProfiling(name: string) {

--- a/src/hubextensions.hub.test.ts
+++ b/src/hubextensions.hub.test.ts
@@ -47,6 +47,9 @@ describe('hubextensions', () => {
   });
 
   it('respect max profile duration timeout', async () => {
+    // it seems that in node 19 globals (or least part of them) are a readonly object
+    // so when useFakeTimers is called it throws an error because it cannot override
+    // a readonly property of performance on global object. Use legacyFakeTimers for now
     jest.useFakeTimers({ legacyFakeTimers: true });
     const startProfilingSpy = jest.spyOn(profiler, 'startProfiling');
     const stopProfilingSpy = jest.spyOn(profiler, 'stopProfiling');

--- a/src/hubextensions.hub.test.ts
+++ b/src/hubextensions.hub.test.ts
@@ -47,7 +47,7 @@ describe('hubextensions', () => {
   });
 
   it('respect max profile duration timeout', async () => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ legacyFakeTimers: true });
     const startProfilingSpy = jest.spyOn(profiler, 'startProfiling');
     const stopProfilingSpy = jest.spyOn(profiler, 'stopProfiling');
     const transport = Sentry.getCurrentHub().getClient()?.getTransport();


### PR DESCRIPTION
This PR adds support for compiling to node 19 target (fixes https://github.com/getsentry/profiling-node/issues/78)