### PR TITLE
fix(segfault): fix return value order

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -235,7 +235,8 @@ export function createProfilingEventEnvelope(
 
   const envelopeItem: EventItem = [
     {
-      // @ts-expect-error profile is not yet a type in @sentry/types
+      // eslint-disable-next-line
+      // @ts-ignore profile is not yet a type in @sentry/types
       type: 'profile'
     },
     // @ts-expect-error profile is not yet a type in @sentry/types


### PR DESCRIPTION
Fixes a segfault on gcloud (tested by deploying our own service). Not exactly sure what the exact cause was, but it seems it had something to do with setting a return value before deleting a profile.