### PR TITLE
fix(env): read env from sdk

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,7 @@ export interface Profile {
   };
   timestamp: string;
   release: string;
+  environment: string;
   platform: string;
   profile: ThreadCpuProfile;
   debug_meta?: {
@@ -216,6 +217,7 @@ export function createProfilingEventEnvelope(
     platform: 'node',
     version: '1',
     release: event.release || '',
+    environment: event.environment || '',
     runtime: {
       name: 'node',
       version: process.versions.node || ''


### PR DESCRIPTION
Read env from sdk init and pass it along, this was previously missed.

Link in relay https://github.com/getsentry/relay/blob/760a62aeafb8bc69071950624318a7d17ac81087/relay-profiling/src/sample.rs#L142