### PR TITLE
docs: update install link for sentry profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Profiling works as an extension of tracing so you will need both @sentry/tracing
 yarn add @sentry/tracing @sentry/profiling-node
 
 # Using npm
-npm install --save @sentry/tracing sentry/profiling-node
+npm install --save @sentry/tracing @sentry/profiling-node
 ```
 
 ## Usage


### PR DESCRIPTION
Updated readme with correct link to installing `@sentry/profiling-node` dependency

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes.
