### PR TITLE
ref: remove profile context before sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "benchmark:server": "node benchmarks/cpu/benchmark.server.js",
     "benchmark:format": "node benchmarks/format/benchmark.format.js",
     "benchmark:integration": "node benchmarks/cpu/benchmark.integration.base.js && node benchmarks/cpu/benchmark.integration.disabled.js && node benchmarks/cpu/benchmark.integration.js",
-    "test:watch": "jest --watch",
+    "test:watch": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib/binaries jest --watch",
     "test": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib/binaries jest --config jest.config.ts",
     "prettier": "prettier --config ./.prettierrc --write"
   },

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -119,8 +119,8 @@ export class ProfilingIntegration implements Integration {
           }
 
           // Remove the profile from the transaction context before sending, relay will take care of the rest.
-          if (profiledTransaction?.contexts?.profile) {
-            delete profiledTransaction.contexts.profile;
+          if (profiledTransaction?.contexts?.['.profile']) {
+            delete profiledTransaction.contexts['profile'];
           }
 
           // We need to find both a profile and a transaction event for the same profile_id.

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -118,6 +118,11 @@ export class ProfilingIntegration implements Integration {
             throw new TypeError('[Profiling] cannot find profile for a transaction without a profile context');
           }
 
+          // Remove the profile from the transaction context before sending, relay will take care of the rest.
+          if (profiledTransaction?.contexts?.profile) {
+            delete profiledTransaction.contexts.profile;
+          }
+
           // We need to find both a profile and a transaction event for the same profile_id.
           const profileIndex = PROFILE_QUEUE.findIndex((p) => p.profile_id === profile_id);
           if (profileIndex === -1) {


### PR DESCRIPTION
Deletes profile context before sending data to the backend, we keep it locally so we can associate the txn with profile, but delete before sending