### PR TITLE
fix(build): enumerate precompiled binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
   test-bundle:
     runs-on: ubuntu-latest
     needs: [precompile-bindings]
-    if: startsWith(github.ref, 'refs/heads/release/')
+    # if: startsWith(github.ref, 'refs/heads/release/')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,7 @@ jobs:
         with: 
           name: binaries-${{ github.sha }}
           path: lib/
+      - run: ls -l lib/
       - run: npm run test:bundle
 
   build-and-pack:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,14 +167,14 @@ jobs:
 
       # continue with common steps
       - name: Log binary
-        run: du -sh lib/binaries/*
+        run: du -sh lib/*
 
       - name: Archive binary
         uses: actions/upload-artifact@v3
         with:
           name: binaries-${{ github.sha }}
           path: |
-            ${{ github.workspace }}/lib/binaries/
+            ${{ github.workspace }}/lib/*.node
 
   build-and-pack:
     runs-on: ubuntu-latest
@@ -195,8 +195,8 @@ jobs:
       - uses: actions/download-artifact@v3
         with: 
           name: binaries-${{ github.sha }}
-          path: lib/binaries
-      - run: ls -l lib/binaries
+          path: lib/
+      - run: ls -l lib/
       - run: npm pack
 
       - name: Archive artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,23 +25,23 @@ jobs:
           # distributions and container images.
 
           # linux x64 glibc
-          - os: ubuntu-20.04
-            node: 14
-          - os: ubuntu-20.04
-            node: 16
-          - os: ubuntu-20.04
-            node: 18
+          # - os: ubuntu-20.04
+          #   node: 14
+          # - os: ubuntu-20.04
+          #   node: 16
+          # - os: ubuntu-20.04
+          #   node: 18
 
-          # linux x64 musl
-          - os: ubuntu-20.04
-            container: node:14-alpine3.16
-            node: 14
-          - os: ubuntu-20.04
-            container: node:16-alpine3.16
-            node: 16
-          - os: ubuntu-20.04
-            container: node:18-alpine3.17
-            node: 18
+          # # linux x64 musl
+          # - os: ubuntu-20.04
+          #   container: node:14-alpine3.16
+          #   node: 14
+          # - os: ubuntu-20.04
+          #   container: node:16-alpine3.16
+          #   node: 16
+          # - os: ubuntu-20.04
+          #   container: node:18-alpine3.17
+          #   node: 18
 
           # linux aarch64 glibc
           - os: ubuntu-20.04
@@ -69,29 +69,29 @@ jobs:
             node: 18
 
             # macos x64
-          - os: macos-11
-            node: 16
-            arch: x64
-          - os: macos-11
-            node: 18
-            arch: x64
-            # windows x86 
-            # We are not precompiling binaries for node v14 on windows x86 and x64
-            # because the combined size of those two binaries is 2x the size of all the
-            # other binaries combined.
-          - os: windows-2019
-            node: 16
-            arch: x86
-          - os: windows-2019
-            node: 18
-            arch: x86
-            # windows x64
-          - os: windows-2019
-            node: 16
-            arch: x64
-          - os: windows-2019
-            node: 18
-            arch: x64
+          # - os: macos-11
+          #   node: 16
+          #   arch: x64
+          # - os: macos-11
+          #   node: 18
+          #   arch: x64
+          #   # windows x86 
+          #   # We are not precompiling binaries for node v14 on windows x86 and x64
+          #   # because the combined size of those two binaries is 2x the size of all the
+          #   # other binaries combined.
+          # - os: windows-2019
+          #   node: 16
+          #   arch: x86
+          # - os: windows-2019
+          #   node: 18
+          #   arch: x86
+          #   # windows x64
+          # - os: windows-2019
+          #   node: 16
+          #   arch: x64
+          # - os: windows-2019
+          #   node: 18
+          #   arch: x64
           # For some reason it seems like it takes forever for 
           # the macos-m1 runners to start up, so we'll just skip it
           # - os: macos-m1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
    branches:
       - main
       - release/**
+      - jb/build/enum-binaries
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,25 +25,26 @@ jobs:
           # distributions and container images.
 
           # linux x64 glibc
-          # - os: ubuntu-20.04
-          #   node: 14
-          # - os: ubuntu-20.04
-          #   node: 16
-          # - os: ubuntu-20.04
-          #   node: 18
+          - os: ubuntu-20.04
+            node: 14
+          - os: ubuntu-20.04
+            node: 16
+          - os: ubuntu-20.04
+            node: 18
 
-          # # linux x64 musl
-          # - os: ubuntu-20.04
-          #   container: node:14-alpine3.16
-          #   node: 14
-          # - os: ubuntu-20.04
-          #   container: node:16-alpine3.16
-          #   node: 16
-          # - os: ubuntu-20.04
-          #   container: node:18-alpine3.17
-          #   node: 18
+          # linux x64 musl
+          - os: ubuntu-20.04
+            container: node:14-alpine3.16
+            node: 14
+          - os: ubuntu-20.04
+            container: node:16-alpine3.16
+            node: 16
+          - os: ubuntu-20.04
+            container: node:18-alpine3.17
+            node: 18
 
-          # linux aarch64 glibc
+          # Since github does not support arm64 runners, we cross compile from x64 using node_gyp --target_arch=arm64
+          # linux arm64 glibc
           - os: ubuntu-20.04
             arch: arm64
             node: 14
@@ -54,7 +55,7 @@ jobs:
             arch: arm64
             node: 18
 
-          # linux aarch64 musl
+          # linux arm64 musl
           - os: ubuntu-20.04
             container: node:14-alpine3.16
             arch: arm64
@@ -69,29 +70,29 @@ jobs:
             node: 18
 
             # macos x64
-          # - os: macos-11
-          #   node: 16
-          #   arch: x64
-          # - os: macos-11
-          #   node: 18
-          #   arch: x64
-          #   # windows x86 
-          #   # We are not precompiling binaries for node v14 on windows x86 and x64
-          #   # because the combined size of those two binaries is 2x the size of all the
-          #   # other binaries combined.
-          # - os: windows-2019
-          #   node: 16
-          #   arch: x86
-          # - os: windows-2019
-          #   node: 18
-          #   arch: x86
-          #   # windows x64
-          # - os: windows-2019
-          #   node: 16
-          #   arch: x64
-          # - os: windows-2019
-          #   node: 18
-          #   arch: x64
+          - os: macos-11
+            node: 16
+            arch: x64
+          - os: macos-11
+            node: 18
+            arch: x64
+            # windows x86 
+            # We are not precompiling binaries for node v14 on windows x86 and x64
+            # because the combined size of those two binaries is 2x the size of all the
+            # other binaries combined.
+          - os: windows-2019
+            node: 16
+            arch: x86
+          - os: windows-2019
+            node: 18
+            arch: x86
+            # windows x64
+          - os: windows-2019
+            node: 16
+            arch: x64
+          - os: windows-2019
+            node: 18
+            arch: x64
           # For some reason it seems like it takes forever for 
           # the macos-m1 runners to start up, so we'll just skip it
           # - os: macos-m1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,10 +175,26 @@ jobs:
           name: binaries-${{ github.sha }}
           path: |
             ${{ github.workspace }}/lib/*.node
+  test-bundle:
+    runs-on: ubuntu-latest
+    needs: [precompile-bindings]
+    if: startsWith(github.ref, 'refs/heads/release/')
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build:lib
+      - uses: actions/download-artifact@v3
+        with: 
+          name: binaries-${{ github.sha }}
+          path: lib/
+      - run: npm run test:bundle
 
   build-and-pack:
     runs-on: ubuntu-latest
-    needs: [precompile-bindings]
+    needs: [precompile-bindings, test-bundle]
     # Build artifacts are only needed for releasing workflow.
     if: startsWith(github.ref, 'refs/heads/release/')
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,13 +132,13 @@ jobs:
         if: matrix.arch != 'arm64'
         run: npm run test --silent
       
-      # configure build test copy aarch64
-      - name: setup (aarch64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
+      # configure build test copy arm64
+      - name: setup (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
         if: matrix.arch == 'arm64' && !contains(matrix.container, 'alpine')
         run: |
           sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           
-      - name: "Configure gyp (aarch64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
+      - name: "Configure gyp (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
         if: matrix.arch == 'arm64'
         run: npm run build:configure:arm64
 
@@ -149,17 +149,17 @@ jobs:
           tar -xzvf aarch64-linux-musl-cross.tgz
           $(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc --version
 
-      - name: "Build bindings (aarch64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
+      - name: "Build bindings (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
         if: matrix.arch == 'arm64' && contains(matrix.container, 'alpine')
         run: |
           CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc \
           CXX=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++ \
-          npm run build:bindings
+          BUILD_ARCH=arm64 npm run build:bindings
 
-      - name: "Build bindings (aarch64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
+      - name: "Build bindings (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
         if: matrix.arch == 'arm64' && !contains(matrix.container, 'alpine')
         run: |
-          npm run build:bindings:arm64
+          BUILD_ARCH=arm64 npm run build:bindings:arm64
 
       # This will obviously not work as we run on x64, but we should
       # investigate into adding qemu or equiv to run tests on compiled binaries

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 coverage/
 lib/
+build-test/
 
 node_modules/
 memory_db

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 coverage/
 lib/
-binaries/
 
 node_modules/
 memory_db

--- a/esbuild.binaries-copy.js
+++ b/esbuild.binaries-copy.js
@@ -1,0 +1,15 @@
+// eslint-env node
+import esbuild from 'esbuild';
+
+esbuild.build({
+  platform: 'node',
+  entryPoints: ['./src/index.ts'],
+  outfile: './lib/index.js',
+  format: 'cjs',
+  target: 'node12',
+  bundle: true,
+  tsconfig: './tsconfig.cjs.json',
+  loader: {
+    '.node': 'copy'
+  }
+});

--- a/esbuild.cjs.js
+++ b/esbuild.cjs.js
@@ -1,4 +1,5 @@
-// eslint-env node
+import esbuild from 'esbuild';
+
 let missingBindingsPlugin = {
   name: 'MissingBindings',
   setup(build) {
@@ -10,7 +11,7 @@ let missingBindingsPlugin = {
   }
 };
 
-require('esbuild').build({
+esbuild.build({
   platform: 'node',
   entryPoints: ['./src/index.ts'],
   outfile: './lib/index.js',

--- a/esbuild.cjs.js
+++ b/esbuild.cjs.js
@@ -1,10 +1,22 @@
 // eslint-env node
+let missingBindingsPlugin = {
+  name: 'MissingBindings',
+  setup(build) {
+    build.onResolve({ filter: /\.node$/ }, (args) => ({
+      path: args.path,
+      namespace: 'missing-bindings',
+      external: true
+    }));
+  }
+};
+
 require('esbuild').build({
   platform: 'node',
   entryPoints: ['./src/index.ts'],
-  outfile: './lib/cjs/index.js',
+  outfile: './lib/index.js',
   format: 'cjs',
   target: 'node12',
   bundle: true,
-  tsconfig: './tsconfig.cjs.json'
+  tsconfig: './tsconfig.cjs.json',
+  plugins: [missingBindingsPlugin]
 });

--- a/esbuild.esm.js
+++ b/esbuild.esm.js
@@ -1,4 +1,5 @@
-// eslint-env node
+import esbuild from 'esbuild';
+
 let missingBindingsPlugin = {
   name: 'MissingBindings',
   setup(build) {
@@ -10,7 +11,7 @@ let missingBindingsPlugin = {
   }
 };
 
-require('esbuild').build({
+esbuild.build({
   platform: 'node',
   entryPoints: ['./src/index.ts'],
   outfile: './lib/index.mjs',

--- a/esbuild.esm.js
+++ b/esbuild.esm.js
@@ -1,20 +1,22 @@
 // eslint-env node
+let missingBindingsPlugin = {
+  name: 'MissingBindings',
+  setup(build) {
+    build.onResolve({ filter: /\.node$/ }, (args) => ({
+      path: args.path,
+      namespace: 'missing-bindings',
+      external: true
+    }));
+  }
+};
+
 require('esbuild').build({
   platform: 'node',
   entryPoints: ['./src/index.ts'],
-  outfile: './lib/esm/index.mjs',
+  outfile: './lib/index.mjs',
   format: 'esm',
   target: 'esnext',
   bundle: true,
   tsconfig: './tsconfig.esm.json',
-  banner: {
-    js: `
-  import {dirname as topLevelAliasedDirname} from 'path';
-    import { fileURLToPath } from 'url';
-    import { createRequire as topLevelCreateRequire } from 'module';
-    const require = topLevelCreateRequire(import.meta.url);
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = topLevelAliasedDirname(__filename);
-  //   `
-  }
+  plugins: [missingBindingsPlugin]
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,12 @@ const config: Config = {
   transform: {
     // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
     // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
-    '^.+\\.tsx?$': ['ts-jest', {}]
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json'
+      }
+    ]
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "npm run build:bindings && npm run build:lib",
     "build:lib:esm": "node scripts/esm.mod.js && node ./esbuild.esm.js",
     "build:lib:cjs": "node scripts/cjs.mod.js && node ./esbuild.cjs.js",
-    "build:lib": "tsc -p ./tsconfig.types.json && npm run build:lib:cjs && npm run build:lib:esm",
+    "build:lib": "tsc -p ./tsconfig.types.json && npm run build:lib:esm && npm run build:lib:cjs",
     "build:configure": "node-gyp configure",
     "build:configure:arm64": "node-gyp configure --arch=arm64",
     "build:bindings": "node-gyp build && node scripts/copy-target.js",
@@ -53,8 +53,8 @@
     "benchmark:server": "node benchmarks/cpu/benchmark.server.js",
     "benchmark:format": "node benchmarks/format/benchmark.format.js",
     "benchmark:integration": "node benchmarks/cpu/benchmark.integration.base.js && node benchmarks/cpu/benchmark.integration.disabled.js && node benchmarks/cpu/benchmark.integration.js",
-    "test:watch": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib jest --watch",
-    "test": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib jest --config jest.config.ts",
+    "test:watch": "cross-env SENTRY_PROFILER_BINARY_DIR=./lib jest --watch",
+    "test": "cross-env SENTRY_PROFILER_BINARY_DIR=./lib jest --config jest.config.ts",
     "prettier": "prettier --config ./.prettierrc --write"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/getsentry/profiling-node.git"
   },
+  "type": "module",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "benchmark:format": "node benchmarks/format/benchmark.format.js",
     "benchmark:integration": "node benchmarks/cpu/benchmark.integration.base.js && node benchmarks/cpu/benchmark.integration.disabled.js && node benchmarks/cpu/benchmark.integration.js",
     "test:watch": "cross-env SENTRY_PROFILER_BINARY_DIR=./lib jest --watch",
+    "test:bundle": "node test-binaries.esbuild.js",
     "test": "cross-env SENTRY_PROFILER_BINARY_DIR=./lib jest --config jest.config.ts",
     "prettier": "prettier --config ./.prettierrc --write"
   },

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "type": "git",
     "url": "https://github.com/getsentry/profiling-node.git"
   },
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.mjs",
-  "types": "lib/types/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.mjs",
+  "types": "lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/cjs/index.js",
-      "import": "./lib/esm/index.mjs",
-      "types": "./lib/types/index.d.ts"
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "engines": {
@@ -40,7 +40,7 @@
     "build": "npm run build:bindings && npm run build:lib",
     "build:lib:esm": "node scripts/esm.mod.js && node ./esbuild.esm.js",
     "build:lib:cjs": "node scripts/cjs.mod.js && node ./esbuild.cjs.js",
-    "build:lib": "tsc -p ./tsconfig.types.json && npm run build:lib:esm && npm run build:lib:cjs",
+    "build:lib": "tsc -p ./tsconfig.types.json && npm run build:lib:cjs && npm run build:lib:esm",
     "build:configure": "node-gyp configure",
     "build:configure:arm64": "node-gyp configure --arch=arm64",
     "build:bindings": "node-gyp build && node scripts/copy-target.js",
@@ -53,8 +53,8 @@
     "benchmark:server": "node benchmarks/cpu/benchmark.server.js",
     "benchmark:format": "node benchmarks/format/benchmark.format.js",
     "benchmark:integration": "node benchmarks/cpu/benchmark.integration.base.js && node benchmarks/cpu/benchmark.integration.disabled.js && node benchmarks/cpu/benchmark.integration.js",
-    "test:watch": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib/binaries jest --watch",
-    "test": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib/binaries jest --config jest.config.ts",
+    "test:watch": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib jest --watch",
+    "test": "cross-env SENTRY_PROFILER_BINARY_DIR=../lib jest --config jest.config.ts",
     "prettier": "prettier --config ./.prettierrc --write"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build:configure": "node-gyp configure",
     "build:configure:arm64": "node-gyp configure --arch=arm64",
     "build:bindings": "node-gyp build && node scripts/copy-target.js",
-    "build:bindings:arm64": "BUILD_ARCH=arm64 node-gyp build --arch=arm64 && node scripts copy-target.js",
+    "build:bindings:arm64": "BUILD_ARCH=arm64 node-gyp build --arch=arm64 && node scripts/copy-target.js",
     "build:benchmark:format": "node-gyp -DFORMAT_BENCHMARK=1 build",
     "build:dev": "npm run clean && npm run build:configure && npm run build",
     "benchmark": "npm run benchmark:methods && npm run benchmark:profiler && npm run benchmark:server && npm run benchmark:format",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build:configure": "node-gyp configure",
     "build:configure:arm64": "node-gyp configure --arch=arm64",
     "build:bindings": "node-gyp build && node scripts/copy-target.js",
-    "build:bindings:arm64": "node-gyp build --arch=arm64",
+    "build:bindings:arm64": "BUILD_ARCH=arm64 node-gyp build --arch=arm64 && node scripts copy-target.js",
     "build:benchmark:format": "node-gyp -DFORMAT_BENCHMARK=1 build",
     "build:dev": "npm run clean && npm run build:configure && npm run build",
     "benchmark": "npm run benchmark:methods && npm run benchmark:profiler && npm run benchmark:server && npm run benchmark:format",

--- a/playground/express/index.js
+++ b/playground/express/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const Sentry = require('@sentry/node');
 const Tracing = require('@sentry/tracing');
-const { ProfilingIntegration } = require('../../lib/cjs');
+const { ProfilingIntegration } = require('../../lib');
 
 const app = express();
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/scripts/binaries.js
+++ b/scripts/binaries.js
@@ -10,7 +10,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 export function getModuleName() {
   const stdlib = familySync();
   const platform = os.platform();
-  const arch = process.env.BUILD_ARCH || os.arch();
+  const arch = process.env['BUILD_ARCH'] || os.arch();
 
   const identifier = [platform, arch, stdlib, getAbi(process.versions.node, 'node')]
     .filter((c) => c !== undefined && c !== null)

--- a/scripts/binaries.js
+++ b/scripts/binaries.js
@@ -9,10 +9,10 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export function getModuleName() {
   const stdlib = familySync();
-  const userPlatform = os.platform();
-  const userArchitecture = process.env.BUILD_ARCH || os.arch();
+  const platform = os.platform();
+  const arch = os.arch();
 
-  const identifier = [userPlatform, userArchitecture, stdlib, getAbi(process.versions.node, 'node')]
+  const identifier = [platform, arch, stdlib, getAbi(process.versions.node, 'node')]
     .filter((c) => c !== undefined && c !== null)
     .join('-');
 

--- a/scripts/binaries.js
+++ b/scripts/binaries.js
@@ -10,7 +10,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 export function getModuleName() {
   const stdlib = familySync();
   const platform = os.platform();
-  const arch = os.arch();
+  const arch = process.env.BUILD_ARCH || os.arch();
 
   const identifier = [platform, arch, stdlib, getAbi(process.versions.node, 'node')]
     .filter((c) => c !== undefined && c !== null)

--- a/scripts/binaries.js
+++ b/scripts/binaries.js
@@ -1,10 +1,13 @@
-/* eslint-env node */
-const os = require('os');
-const path = require('path');
-const { getAbi } = require('node-abi');
-const { familySync } = require('detect-libc');
+import os from 'os';
+import path from 'path';
+import { getAbi } from 'node-abi';
+import { familySync } from 'detect-libc';
+import process from 'process';
+import { fileURLToPath, URL } from 'url';
 
-function getModuleName() {
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export function getModuleName() {
   const stdlib = familySync();
   const userPlatform = os.platform();
   const userArchitecture = process.env.BUILD_ARCH || os.arch();
@@ -16,9 +19,5 @@ function getModuleName() {
   return `sentry_cpu_profiler-${identifier}.node`;
 }
 
-const source = path.join(__dirname, '..', 'build', 'Release', 'sentry_cpu_profiler.node');
-const target = path.join(__dirname, '..', 'lib', getModuleName());
-
-module.exports.getModuleName = getModuleName;
-module.exports.target = target;
-module.exports.source = source;
+export const source = path.join(__dirname, '..', 'build', 'Release', 'sentry_cpu_profiler.node');
+export const target = path.join(__dirname, '..', 'lib', getModuleName());

--- a/scripts/binaries.js
+++ b/scripts/binaries.js
@@ -5,17 +5,19 @@ const { getAbi } = require('node-abi');
 const { familySync } = require('detect-libc');
 
 function getModuleName() {
-  const family = familySync();
+  const stdlib = familySync();
   const userPlatform = os.platform();
   const userArchitecture = process.env.BUILD_ARCH || os.arch();
 
-  const identifier = [userPlatform, userArchitecture, family].filter((c) => c !== undefined && c !== null).join('-');
+  const identifier = [userPlatform, userArchitecture, stdlib, getAbi(process.versions.node, 'node')]
+    .filter((c) => c !== undefined && c !== null)
+    .join('-');
 
-  return `sentry_cpu_profiler-v${getAbi(process.versions.node, 'node')}-${identifier}.node`;
+  return `sentry_cpu_profiler-${identifier}.node`;
 }
 
 const source = path.join(__dirname, '..', 'build', 'Release', 'sentry_cpu_profiler.node');
-const target = path.join(__dirname, '..', 'lib', 'binaries', getModuleName());
+const target = path.join(__dirname, '..', 'lib', getModuleName());
 
 module.exports.getModuleName = getModuleName;
 module.exports.target = target;

--- a/scripts/check-build.js
+++ b/scripts/check-build.js
@@ -1,7 +1,7 @@
-const cp = require('child_process');
-const { existsSync } = require('fs');
-
-const { target } = require('./binaries');
+import cp from 'child_process';
+import { existsSync } from 'fs';
+import process from 'process';
+import { target } from './binaries';
 
 function recompileFromSource() {
   try {

--- a/scripts/check-build.js
+++ b/scripts/check-build.js
@@ -1,7 +1,7 @@
 import cp from 'child_process';
 import { existsSync } from 'fs';
 import process from 'process';
-import { target } from './binaries';
+import { target } from './binaries.js';
 
 function recompileFromSource() {
   try {

--- a/scripts/cjs.mod.js
+++ b/scripts/cjs.mod.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import fs from 'fs';
 let contents = fs.readFileSync('./src/cpu_profiler.ts', 'utf8');
 
 // Convert to CJS

--- a/scripts/cjs.mod.js
+++ b/scripts/cjs.mod.js
@@ -9,7 +9,7 @@ contents = contents.replace(
 
 contents = contents.replace(
   /\/\/\s+__START__REPLACE__REQUIRE__((.|\r|\n)*)__END__REPLACE__REQUIRE__/gm,
-  `// __START__REPLACE__REQUIRE__\nconst _require = require;\n// __END__REPLACE__REQUIRE__`
+  `// __START__REPLACE__REQUIRE__\n\n// __END__REPLACE__REQUIRE__`
 );
 
 fs.writeFileSync('./src/cpu_profiler.ts', contents, 'utf8');

--- a/scripts/copy-target.js
+++ b/scripts/copy-target.js
@@ -5,18 +5,13 @@ const path = require('path');
 const { getModuleName } = require('./binaries');
 
 const lib = path.resolve(__dirname, '..', 'lib');
-const binaries = path.resolve(__dirname, '..', 'lib', 'binaries');
 
 if (!fs.existsSync(lib)) {
   fs.mkdirSync(lib);
 }
 
-if (!fs.existsSync(binaries)) {
-  fs.mkdirSync(binaries);
-}
-
 const source = path.join(__dirname, '..', 'build', 'Release', 'sentry_cpu_profiler.node');
-const target = path.join(__dirname, '..', 'lib', 'binaries', getModuleName());
+const target = path.join(__dirname, '..', 'lib', getModuleName());
 
 console.log('Renaming', source, 'to', target);
 fs.renameSync(source, target);

--- a/scripts/copy-target.js
+++ b/scripts/copy-target.js
@@ -1,9 +1,10 @@
-/* eslint-env node */
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, URL } from 'url';
 
-const { getModuleName } = require('./binaries');
+import { getModuleName } from './binaries.js';
 
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const lib = path.resolve(__dirname, '..', 'lib');
 
 if (!fs.existsSync(lib)) {

--- a/scripts/esm.mod.js
+++ b/scripts/esm.mod.js
@@ -9,7 +9,7 @@ contents = contents.replace(
 
 contents = contents.replace(
   /\/\/\s+__START__REPLACE__REQUIRE__((.|\r|\n)*)__END__REPLACE__REQUIRE__/gm,
-  `// __START__REPLACE__REQUIRE__\nimport { createRequire as aliasedCreateRequire } from 'module';\nconst _require = aliasedCreateRequire(import.meta.url);\n// __END__REPLACE__REQUIRE__`
+  `// __START__REPLACE__REQUIRE__\nimport { createRequire as aliasedCreateRequire } from 'module';\nconst require = aliasedCreateRequire(import.meta.url);\n// __END__REPLACE__REQUIRE__`
 );
 
 fs.writeFileSync('./src/cpu_profiler.ts', contents, 'utf8');

--- a/scripts/esm.mod.js
+++ b/scripts/esm.mod.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import fs from 'fs';
 let contents = fs.readFileSync('./src/cpu_profiler.ts', 'utf8');
 
 // Convert to CJS

--- a/src/cpu_profiler.ts
+++ b/src/cpu_profiler.ts
@@ -20,7 +20,7 @@ export function importCppBindingsModule(): any {
 
   const stdlib = familySync();
   const platform = _platform();
-  const arch = process.env.BUILD_ARCH || _arch();
+  const arch = process.env['BUILD_ARCH'] || _arch();
   const abi = getAbi(versions.node, 'node');
   const identifier = [platform, arch, stdlib, abi].filter((c) => c !== undefined && c !== null).join('-');
 

--- a/src/cpu_profiler.ts
+++ b/src/cpu_profiler.ts
@@ -20,7 +20,7 @@ export function importCppBindingsModule(): any {
 
   const stdlib = familySync();
   const platform = _platform();
-  const arch = env['BUILD_ARCH'] || _arch();
+  const arch = _arch();
   const abi = getAbi(versions.node, 'node');
   const identifier = [platform, arch, stdlib, abi].filter((c) => c !== undefined && c !== null).join('-');
 

--- a/src/cpu_profiler.ts
+++ b/src/cpu_profiler.ts
@@ -20,7 +20,7 @@ export function importCppBindingsModule(): any {
 
   const stdlib = familySync();
   const platform = _platform();
-  const arch = _arch();
+  const arch = process.env.BUILD_ARCH || _arch();
   const abi = getAbi(versions.node, 'node');
   const identifier = [platform, arch, stdlib, abi].filter((c) => c !== undefined && c !== null).join('-');
 

--- a/src/hubextensions.hub.test.ts
+++ b/src/hubextensions.hub.test.ts
@@ -35,6 +35,7 @@ function makeClientWithoutHooks(): [NodeClient, Transport] {
       () => Sentry.getCurrentHub()
     );
   };
+  // @ts-expect-error override private
   client.on = undefined;
   return [client, transport];
 }

--- a/src/hubextensions.test.ts
+++ b/src/hubextensions.test.ts
@@ -78,8 +78,7 @@ describe('hubextensions', () => {
 
     expect(startTransaction).toHaveBeenCalledTimes(1);
     expect(startProfilingSpy).not.toHaveBeenCalled();
-
-    expect(transaction.metadata?.profile).toBeUndefined();
+    expect((transaction.metadata as any)?.profile).toBeUndefined();
   });
   it('skips profiling if profilesSampleRate is set to 0', () => {
     const hub = makeHubMock({ profilesSampleRate: 0 });
@@ -93,7 +92,7 @@ describe('hubextensions', () => {
     expect(startTransaction).toHaveBeenCalledTimes(1);
     expect(startProfilingSpy).not.toHaveBeenCalled();
 
-    expect(transaction.metadata?.profile).toBeUndefined();
+    expect((transaction.metadata as any)?.profile).toBeUndefined();
   });
   it('skips profiling when random > sampleRate', () => {
     const hub = makeHubMock({ profilesSampleRate: 0.5 });
@@ -108,7 +107,7 @@ describe('hubextensions', () => {
     expect(startTransaction).toHaveBeenCalledTimes(1);
     expect(startProfilingSpy).not.toHaveBeenCalled();
 
-    expect(transaction.metadata?.profile).toBeUndefined();
+    expect((transaction.metadata as any)?.profile).toBeUndefined();
   });
   it('starts the profiler', () => {
     const startProfilingSpy = jest.spyOn(profiler, 'startProfiling');
@@ -125,7 +124,7 @@ describe('hubextensions', () => {
     expect(startProfilingSpy).toHaveBeenCalledTimes(1);
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
 
-    expect(transaction.metadata?.profile).toBeDefined();
+    expect((transaction.metadata as any)?.profile).toBeDefined();
   });
 
   it('does not start the profiler if transaction is sampled', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -47,6 +47,7 @@ function makeClientWithoutHooks(): [NodeClient, MockTransport] {
       () => Sentry.getCurrentHub()
     );
   };
+  // @ts-expect-error override private property
   client.on = undefined;
   return [client, transport];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 import { ProfilingIntegration } from './integration';
-
 export { ProfilingIntegration };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -84,9 +84,11 @@ describe('createProfilingEventEnvelope', () => {
   });
   it('throws if profile is undefined', () => {
     expect(() =>
+      // @ts-expect-error mock profile as undefined
       createProfilingEventEnvelope(makeEvent({ type: 'transaction' }, undefined), makeDsn({}), makeSdkMetadata({}))
     ).toThrowError('Cannot construct profiling event envelope without a valid profile. Got undefined instead.');
     expect(() =>
+      // @ts-expect-error mock profile as null
       createProfilingEventEnvelope(makeEvent({ type: 'transaction' }, null), makeDsn({}), makeSdkMetadata({}))
     ).toThrowError('Cannot construct profiling event envelope without a valid profile. Got null instead.');
   });
@@ -205,6 +207,7 @@ describe('createProfilingEventEnvelope', () => {
         makeEvent(
           // @ts-expect-error force invalid value
           { type: 'error' },
+          // @ts-expect-error mock tid as undefined
           makeProfile({ samples: [{ stack_id: 0, thread_id: undefined, elapsed_since_start_ns: '0' }] })
         ),
         makeDsn({}),
@@ -234,7 +237,9 @@ describe('createProfilingEventEnvelope', () => {
         },
         makeProfile({
           samples: [
+            // @ts-expect-error mock tid as undefined
             { stack_id: 0, thread_id: undefined, elapsed_since_start_ns: '0' },
+            // @ts-expect-error mock tid as undefined
             { stack_id: 0, thread_id: undefined, elapsed_since_start_ns: '0' }
           ]
         })
@@ -282,7 +287,7 @@ describe('isValidProfile', () => {
   });
 
   it('is not valid if it does not have a profile_id', () => {
-    expect(isValidProfile(makeProfile({ samples: [], profile_id: undefined }))).toBe(false);
+    expect(isValidProfile(makeProfile({ samples: [], profile_id: undefined } as any))).toBe(false);
   });
 });
 

--- a/test-binaries.entry.js
+++ b/test-binaries.entry.js
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/node';
+import { ProfilingIntegration } from './lib';
+import { setTimeout } from 'node:timers';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+Sentry.init({
+  dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+  integrations: [new ProfilingIntegration()],
+  tracesSampleRate: 1.0,
+  profilesSampleRate: 1.0
+});
+
+const txn = Sentry.startTransaction('Precompile test');
+
+await wait(500);
+txn.finish();

--- a/test-binaries.esbuild.js
+++ b/test-binaries.esbuild.js
@@ -4,7 +4,8 @@ esbuild.build({
   platform: 'node',
   entryPoints: ['./test-binaries.entry.js'],
   outfile: './build-test/test-binaries.js',
-  format: 'cjs',
+  target: 'esnext',
+  format: 'esm',
   bundle: true,
   tsconfig: './tsconfig.cjs.json',
   loader: {

--- a/test-binaries.esbuild.js
+++ b/test-binaries.esbuild.js
@@ -1,12 +1,10 @@
-// eslint-env node
 import esbuild from 'esbuild';
 
 esbuild.build({
   platform: 'node',
-  entryPoints: ['./src/index.ts'],
-  outfile: './lib/index.js',
+  entryPoints: ['./test-binaries.entry.js'],
+  outfile: './test-binaries.js',
   format: 'cjs',
-  target: 'node12',
   bundle: true,
   tsconfig: './tsconfig.cjs.json',
   loader: {

--- a/test-binaries.esbuild.js
+++ b/test-binaries.esbuild.js
@@ -3,7 +3,7 @@ import esbuild from 'esbuild';
 esbuild.build({
   platform: 'node',
   entryPoints: ['./test-binaries.entry.js'],
-  outfile: './test-binaries.js',
+  outfile: './build-test/test-binaries.js',
   format: 'cjs',
   bundle: true,
   tsconfig: './tsconfig.cjs.json',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,5 @@
     "baseUrl": "./src",
     "typeRoots": ["node_modules/@types"],
   },
-  "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts", "scripts/**/*"]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,9 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "lib/cjs",
+        "outDir": "lib",
         "module": "commonjs",
-    }
+        "declaration": false,
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,9 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "lib/esm",
+        "outDir": "lib",
         "module": "ES2020",
-    }
+        "declaration": false,
+    },
+    "include": ["src/**/*.ts"],
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "esModuleInterop": true
+    },
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -2,8 +2,12 @@
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
         "module": "ES2022",
-        "outDir": "lib/types",
+        "outDir": "lib",
         "emitDeclarationOnly": true,
-        "declaration": true,
-    }
+        "declaration": true
+    },
+    "files": [
+        "./src/index.ts",
+    ],
+    "include": ["./src/index.ts"]
 }


### PR DESCRIPTION
Our bindings require call was fully dynamic so bundlers (only tested esbuild and webpack) could not determine the static set of binaries that they need to copy the binaries for, resulting in MODULE_NOT_FOUND runtime error.

This PR fixes this by hardcoding the set of binaries so that they can be copied to the final bundle - the caveat of this approach is that now all precompiled binaries will be copied. Sadly, the approach is not fully forward compatible as missing env/platform/node variants which are not hardcoded will still have to be manually copied.

To ensure we don't break builds by hardcoding binaries and not providing precompiled binaries, I added a step before creating the final npm tarbal which attempts to build a bundle including our profiling package - this triggers .node files to be copied over to outdir folder and errors if any of the hardcoded binaries are not available.