### PR TITLE
fix broken reference to copy-target script

### DIFF
--- a/scripts/check-build.mjs
+++ b/scripts/check-build.mjs
@@ -11,7 +11,7 @@ function recompileFromSource() {
     console.log('@sentry/profiling-node: Compiling from source...');
     cp.execSync(`npm run build:configure`, { env: process.env });
     cp.execSync(`npm run build:bindings`, { env: process.env });
-    cp.execSync('node scripts/copy-target.js', { env: process.env });
+    cp.execSync('node scripts/copy-target.mjs', { env: process.env });
     return true;
   } catch (e) {
     console.error(


### PR DESCRIPTION
Since version [1.0.0-alpha.6](https://github.com/getsentry/profiling-node/releases/tag/v1.0.0-alpha.6) there's a broken reference to `copy-target.js` script, which has been renominated as `copy-target.mjs`.

This prevents the build from source to complete successfully
