### PR TITLE
build: drop esm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
     "url": "https://github.com/getsentry/profiling-node.git"
   },
   "main": "lib/index.js",
-  "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts"
     }
   },
@@ -42,7 +40,7 @@
     "build": "npm run build:bindings && npm run build:lib",
     "build:lib:esm": "node ./esbuild.esm.mjs",
     "build:lib:cjs": "node ./esbuild.cjs.mjs",
-    "build:lib": "tsc -p ./tsconfig.types.json && npm run build:lib:esm && npm run build:lib:cjs",
+    "build:lib": "tsc -p ./tsconfig.types.json && npm run build:lib:cjs",
     "build:configure": "node-gyp configure",
     "build:configure:arm64": "node-gyp configure --arch=arm64",
     "build:bindings": "node-gyp build && node scripts/copy-target.mjs",


### PR DESCRIPTION
This has been causing more headache than it is worth. Tldr, but pure esm cannot import .node files (unknown file extension error) and using createRequire(import.meta.url) breaks bundlers 😭