### PR TITLE
fix: Issue fixed for building binary with recompileFromSource

### DIFF
--- a/scripts/check-build.mjs
+++ b/scripts/check-build.mjs
@@ -8,9 +8,9 @@ const require = createRequire(import.meta.url);
 
 function recompileFromSource() {
   console.log('@sentry/profiling-node: Compiling from source...');
-  cp.spawnSync(`npm run build:configure && npm run build:bindings && node scripts/copy-target.mjs`, {
-    env: process.env
-  });
+  cp.spawnSync('npm', ['run', 'build:configure'], { env: process.env });
+  cp.spawnSync('npm', ['run', 'build:bindings'], { env: process.env });
+  cp.spawnSync('node', ['scripts/copy-target.mjs'], { env: process.env });
 }
 
 if (existsSync(target)) {


### PR DESCRIPTION
This is a fix for #171 and #141. 

The command in recompileFromSource passed to cp.spawnSync uses the && operator to chain multiple npm scripts together. However, && is a shell operator for command chaining and conditional execution.

cp.spawnSync expects a single command as the first argument, making it incompatible with the && operator usage. && is interpreted by the shell, not as part of a single command.

To resolve this, there are two options:

1. Separate npm scripts into individual commands: Execute each npm script separately using cp.spawnSync. This ensures each script is treated as an independent command, eliminating the need for shell operators like &&.

2. Execute a shell command: Invoke a shell (e.g., sh) and pass the entire chain of npm scripts with && as the argument to cp.spawnSync. However, this introduces a dependency on the shell environment and may lead to platform or shell inconsistencies.

For simplicity and cleanliness, I recommend option 1. It separates npm scripts into individual commands, aligning with cp.spawnSync requirements and improving code manageability.

Please review and let me know if you have any questions or if further adjustments are needed.