### PR TITLE
fix(build): cross compile from x64 to arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
 
       # configure build test copy arm64
       - name: setup (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
-        if: matrix.arch == 'arm64' && !contains(matrix.container, 'alpine')
+        if: matrix.arch == 'arm64' && !contains(matrix.container, 'alpine') && matrix.target_platform != 'darwin'
         run: |
           sudo apt-get update
           sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - release/**
-      - jb/test/darwin-build
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - release/**
-      - jb/ci/test-app
+      - jb/test/darwin-build
   workflow_dispatch:
     inputs:
       commit:
@@ -94,23 +94,18 @@ jobs:
             node: 20
             arch: x64
 
-           # linux arm64 target attempt to cross compile for darwin
-          - os: ubuntu-20.04
-            arch: arm64
-            node: 14
-            target_platform: darwin
-
-          - os: ubuntu-20.04
+            # macos cross compile for darwin
+          - os: macos-12
             arch: arm64
             node: 16
             target_platform: darwin
 
-          - os: ubuntu-20.04
+          - os: macos-12
             arch: arm64
             node: 18
             target_platform: darwin
 
-          - os: ubuntu-20.04
+          - os: macos-12
             arch: arm64
             node: 20
             target_platform: darwin
@@ -128,7 +123,7 @@ jobs:
             node: 20
             arch: x64
 
-          # For some reason it seems like it takes forever for 
+          # For some reason it seems like it takes forever for
           # the macos-m1 runners to start up, so we'll just skip it
           # - os: macos-m1
           #   node: 18
@@ -166,21 +161,21 @@ jobs:
       - name: Test
         if: matrix.arch != 'arm64'
         run: npm run test --silent
-      
+
       # configure build test copy arm64
       - name: setup (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
         if: matrix.arch == 'arm64' && !contains(matrix.container, 'alpine')
         run: |
           sudo apt-get update
           sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          
+
       # linux arm64
       - name: "Configure gyp (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})"
         if: matrix.arch == 'arm64' && matrix.target_platform != 'darwin'
         run: npm run build:configure:arm64
 
       - name: Setup musl cross compiler
-        if: contains(matrix.container, 'alpine') || matrix.target_platform == 'darwin'
+        if: contains(matrix.container, 'alpine')
         run: |
           curl -OL https://musl.cc/aarch64-linux-musl-cross.tgz
           tar -xzvf aarch64-linux-musl-cross.tgz
@@ -201,15 +196,13 @@ jobs:
           BUILD_ARCH=arm64 npm run build:bindings:arm64
 
       # linux arm64 target darwin
-      - name: "Configure gyp (arm64, darwin)"
+      - name: 'Configure gyp (arm64, darwin)'
         if: matrix.arch == 'arm64' && matrix.target_platform == 'darwin'
         run: npm run build:configure:arm64
 
-      - name: "Build bindings (arm64, darwin)"
+      - name: 'Build bindings (arm64, darwin)'
         if: matrix.arch == 'arm64' && matrix.target_platform == 'darwin'
         run: |
-          CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc \
-          CXX=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++ \
           BUILD_PLATFORM=darwin BUILD_ARCH=arm64 npm run build:bindings:arm64
 
       # continue with common steps
@@ -234,7 +227,7 @@ jobs:
       - run: npm ci
       - run: npm run build:lib
       - uses: actions/download-artifact@v3
-        with: 
+        with:
           name: binaries-${{ github.sha }}
           path: lib/
       - run: ls -l lib/
@@ -255,7 +248,7 @@ jobs:
       - run: npm run build:lib
 
       - uses: actions/download-artifact@v3
-        with: 
+        with:
           name: binaries-${{ github.sha }}
           path: lib/
       - run: ls -l lib/
@@ -275,13 +268,13 @@ jobs:
     # Build artifacts are only needed for releasing workflow.
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         # The matrix should really be ["webpack", "esbuild", "rollup"],
         # however both rollup and webpack currently crash at runtime.
 
         # The webpack generated bundle crashes at runtime with
         # TypeError: profiling.ProfilingIntegration is not a constructor
-        # ^^ Seems like a generic import syntax erro, however when I log the bundle, 
+        # ^^ Seems like a generic import syntax erro, however when I log the bundle,
         # it actually contains {LRUMap: [Function LRUMap]} which is incorrect.
         # It seems like webpack either mangles the import, or pulls it from some
         # unknown source? I currently dont have the bandwidth to debug why, but contributions
@@ -297,10 +290,10 @@ jobs:
 
         # The general workflow for testing a bundler workflow
         # is to build our library, download the generated binaries and
-        # use npm link to link the what will be our final published library 
+        # use npm link to link the what will be our final published library
         # into the demo_app folder. From there, we run the different bundler
         # build commands and attempt to run the demo app.
-        bundler: ["esbuild"]
+        bundler: ['esbuild']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -311,7 +304,7 @@ jobs:
       - run: npm run build:lib
 
       - uses: actions/download-artifact@v3
-        with: 
+        with:
           name: binaries-${{ github.sha }}
           path: lib/
       - run: ls -l lib/
@@ -320,4 +313,3 @@ jobs:
       - run: npm run test:setup:bundle
       - run: npm run test:${{matrix.bundler}}:build
       - run: npm run test:${{matrix.bundler}}:run
-

--- a/src/cpu_profiler.test.ts
+++ b/src/cpu_profiler.test.ts
@@ -220,7 +220,7 @@ describe('Profiler bindings', () => {
     }
     expect(heap_usage.values.length).toBeGreaterThan(6);
     expect(heap_usage.values.length).toBeLessThanOrEqual(11);
-    expect(heap_usage.unit).toBe('bytes');
+    expect(heap_usage.unit).toBe('byte');
     expect(heap_usage.values.every((v) => v.value > 0)).toBe(true);
     assertValidMeasurements(profile.measurements['memory_footprint']);
   });

--- a/src/cpu_profiler.test.ts
+++ b/src/cpu_profiler.test.ts
@@ -219,7 +219,9 @@ describe('Profiler bindings', () => {
       throw new Error('memory_footprint is null');
     }
     expect(heap_usage.values.length).toBeGreaterThan(6);
-    expect(heap_usage.values.length).toBeLessThanOrEqual(10);
+    expect(heap_usage.values.length).toBeLessThanOrEqual(11);
+    expect(heap_usage.unit).toBe('bytes');
+    expect(heap_usage.values.every((v) => v.value > 0)).toBe(true);
     assertValidMeasurements(profile.measurements['memory_footprint']);
   });
 
@@ -233,7 +235,9 @@ describe('Profiler bindings', () => {
       throw new Error('cpu_usage is null');
     }
     expect(cpu_usage.values.length).toBeGreaterThan(6);
-    expect(cpu_usage.values.length).toBeLessThanOrEqual(10);
+    expect(cpu_usage.values.length).toBeLessThanOrEqual(11);
+    expect(cpu_usage.values.every((v) => v.value > 0)).toBe(true);
+    expect(cpu_usage.unit).toBe('percent');
     assertValidMeasurements(profile.measurements['cpu_usage']);
   });
 

--- a/src/cpu_profiler.ts
+++ b/src/cpu_profiler.ts
@@ -50,9 +50,6 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
     }
 
     if (arch === 'arm64') {
-      if (abi === '83') {
-        return require('./sentry_cpu_profiler-darwin-arm64-83.node');
-      }
       if (abi === '93') {
         return require('./sentry_cpu_profiler-darwin-arm64-93.node');
       }


### PR DESCRIPTION
Cross compile from x86 to arm64 on macos image, doing that from ubuntu causes binaries to throw with mach-o file.

Manually tested by downloading the binaries from GHA and requiring them