### PR TITLE
fix: dont throw if profiler returns nulptr

### DIFF
--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -337,11 +337,6 @@ v8::CpuProfile* SentryProfile::Stop(Profiler* profiler) {
   // If for some reason stopProfiling was called with an invalid profile title or
   // if that title had somehow been stopped already, profile will be null.
   status = ProfileStatus::kStopped;
-
-  if (!profile) {
-    return nullptr;
-  };
-
   return profile;
 }
 
@@ -913,8 +908,6 @@ static napi_value StopProfiling(napi_env env, napi_callback_info info) {
   // If for some reason stopProfiling was called with an invalid profile title or
   // if that title had somehow been stopped already, profile will be null.
   if (!cpu_profile) {
-    napi_throw_error(env, "NAPI_ERROR", "StopProfiling: Stopping Sentry profile did not return a profile.");
-
     CleanupSentryProfile(profiler, profile->second, profile_id);
 
     napi_value napi_null;

--- a/src/cpu_profiler.test.ts
+++ b/src/cpu_profiler.test.ts
@@ -160,6 +160,28 @@ describe('Profiler bindings', () => {
     expect(second).toBe(null);
   });
 
+  it('weird cases', () => {
+    CpuProfilerBindings.startProfiling('same-title');
+    expect(() => {
+      CpuProfilerBindings.stopProfiling('same-title');
+      CpuProfilerBindings.stopProfiling('same-title');
+    }).not.toThrow();
+  });
+
+  it('does not crash if stopTransaction is called before startTransaction', () => {
+    expect(CpuProfilerBindings.stopProfiling('does not exist')).toBe(null);
+  });
+
+  it('does crash if name is invalid', () => {
+    expect(() => CpuProfilerBindings.stopProfiling('')).toThrow();
+    // @ts-expect-error test invalid input
+    expect(() => CpuProfilerBindings.stopProfiling(undefined)).toThrow();
+    // @ts-expect-error test invalid input
+    expect(() => CpuProfilerBindings.stopProfiling(null)).toThrow();
+    // @ts-expect-error test invalid input
+    expect(() => CpuProfilerBindings.stopProfiling({})).toThrow();
+  });
+
   it('does not throw if stopTransaction is called before startTransaction', () => {
     expect(CpuProfilerBindings.stopProfiling('does not exist')).toBe(null);
     expect(() => CpuProfilerBindings.stopProfiling('does not exist')).not.toThrow();

--- a/src/hubextensions.hub.test.ts
+++ b/src/hubextensions.hub.test.ts
@@ -327,6 +327,19 @@ describe('hubextensions', () => {
     });
   });
 
+  it('does not crash if stop is called multiple times', async () => {
+    const stopProfilingSpy = jest.spyOn(CpuProfilerBindings, 'stopProfiling');
+
+    const [client] = makeClientWithoutHooks();
+    const hub = Sentry.getCurrentHub();
+    hub.bindClient(client);
+
+    const transaction = Sentry.getCurrentHub().startTransaction({ name: 'txn' });
+    transaction.finish();
+    transaction.finish();
+    expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('enriches profile with debug_id', async () => {
     GLOBAL_OBJ._sentryDebugIds = {
       'Error\n    at filename.js (filename.js:36:15)': 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -57,12 +57,12 @@ export class ProfilingIntegration implements Integration {
           const maxProfileDurationMs =
             (options._experiments && options._experiments['maxProfileDurationMs']) || MAX_PROFILE_DURATION_MS;
 
-          // Enqueue a timeout to prevent profiles from running over max duration.
           if (PROFILE_TIMEOUTS[profile_id]) {
             global.clearTimeout(PROFILE_TIMEOUTS[profile_id]);
             delete PROFILE_TIMEOUTS[profile_id];
           }
 
+          // Enqueue a timeout to prevent profiles from running over max duration.
           PROFILE_TIMEOUTS[profile_id] = global.setTimeout(() => {
             if (isDebugBuild()) {
               logger.log('[Profiling] max profile duration elapsed, stopping profiling for:', transaction.name);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,7 +141,7 @@ export function createProfilingEventFromTransaction(event: ProfiledEvent): Profi
     event_id: event.event_id || '',
     transaction: event.transaction || '',
     start_timestamp: event.start_timestamp ? event.start_timestamp * 1000 : Date.now(),
-    trace_id: event?.contexts?.trace?.trace_id || '',
+    trace_id: (event?.contexts?.['trace']?.['trace_id'] as string) || '',
     profile_id: rawProfile.profile_id
   });
 }
@@ -162,7 +162,7 @@ export function createProfilingEvent(profile: RawThreadCpuProfile, event: Event)
     event_id: event.event_id || '',
     transaction: event.transaction || '',
     start_timestamp: event.start_timestamp ? event.start_timestamp * 1000 : Date.now(),
-    trace_id: event?.contexts?.trace?.trace_id || '',
+    trace_id: (event?.contexts?.['trace']?.['trace_id'] as string) || '',
     profile_id: profile.profile_id
   });
 }


### PR DESCRIPTION
Removing the throw call added in https://github.com/getsentry/profiling-node/pull/187/files#r1316130323 and unblocks #196

I did not manage to find a root cause quickly so I am removing the throw call in order to unblock users (it was added recently). I've looked through the timeout logic and did not find any issues (I have added some more tests). Since nulptr is a valid return from the profiler we should just handle it gracefully anyways