### PR TITLE
Update README.md to include Next.js 13+ bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ The easiest way to make bundling work with @sentry/profiling-node and other modu
 
 To mark the package as external, use the following configuration:
 
+[Next.js 13+](https://nextjs.org/docs/app/api-reference/next-config-js/serverComponentsExternalPackages)
+```js
+const { withSentryConfig } = require('@sentry/nextjs')
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    // Add the "@sentry/profiling-node" to serverComponentsExternalPackages.
+    serverComponentsExternalPackages: ['@sentry/profiling-node'],
+  },
+}
+
+module.exports = withSentryConfig(
+  nextConfig,
+  { /* ... */ }
+)
+```
+
 [webpack](https://webpack.js.org/configuration/externals/#externals)
 ```js
 externals: {


### PR DESCRIPTION
When trying to run the profiler in Nextjs 13+ I've found that I can't edit directly the "externals" because it' being passed as a function, but this setting exists to declare external packages, which looks to be working on my end (local dev, local build and deploying).

https://nextjs.org/docs/app/api-reference/next-config-js/serverComponentsExternalPackages


-----

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/profiling-node/blob/main/CONTRIBUTING.md) guidelines and verify:

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes.
