### PR TITLE
deps(sentry): bump sentry deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "^7.69.0",
-        "@sentry/hub": "^7.69.0",
-        "@sentry/node": "^7.69.0",
-        "@sentry/types": "^7.69.0",
-        "@sentry/utils": "^7.69.0",
+        "@sentry/core": "^7.76.0",
+        "@sentry/hub": "^7.76.0",
+        "@sentry/node": "^7.76.0",
+        "@sentry/types": "^7.76.0",
+        "@sentry/utils": "^7.76.0",
         "detect-libc": "^2.0.2",
         "node-abi": "^3.47.0",
         "node-gyp": "^9.4.0"
@@ -1912,79 +1912,72 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.69.0.tgz",
-      "integrity": "sha512-4BgeWZUj9MO6IgfO93C9ocP3+AdngqujF/+zB2rFdUe+y9S6koDyUC7jr9Knds/0Ta72N/0D6PwhgSCpHK8s0Q==",
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.76.0.tgz",
+      "integrity": "sha512-QQVIv+LS2sbGf/e5P2dRisHzXpy02dAcLqENLPG4sZ9otRaFNjdFYEqnlJ4qko+ORpJGQEQp/BX7Q/qzZQHlAg==",
       "dependencies": {
-        "@sentry/core": "7.69.0",
-        "@sentry/types": "7.69.0",
-        "@sentry/utils": "7.69.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.69.0.tgz",
-      "integrity": "sha512-V6jvK2lS8bhqZDMFUtvwe2XvNstFQf5A+2LMKCNBOV/NN6eSAAd6THwEpginabjet9dHsNRmMk7WNKvrUfQhZw==",
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.76.0.tgz",
+      "integrity": "sha512-M+ptkCTeCNf6fn7p2MmEb1Wd9/JXUWxIT/0QEc+t11DNR4FYy1ZP2O9Zb3Zp2XacO7ORrlL3Yc+VIfl5JTgjfw==",
       "dependencies": {
-        "@sentry/types": "7.69.0",
-        "@sentry/utils": "7.69.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.69.0.tgz",
-      "integrity": "sha512-71TQ7P5de9+cdW1ETGI9wgi2VNqfyWaM3cnUvheXaSjPRBrr6mhwoaSjo+GGsiwx97Ob9DESZEIhdzcLupzkFA==",
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.76.0.tgz",
+      "integrity": "sha512-fFs4dP/PxgJkzjsz2lpwGeFNB5q3jsLQ52Jo/Tq3Z7caOzo5scOQCVKO024RAG8uf4ICs8FVXCxHT/c4bs5B4A==",
       "dependencies": {
-        "@sentry/core": "7.69.0",
-        "@sentry/types": "7.69.0",
-        "@sentry/utils": "7.69.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.69.0.tgz",
-      "integrity": "sha512-T0NgPcmDQvEuz5hy6aEhXghTHHTWsiP3IWoeEAakDBHAXmtpT6lYFQZgb5AiEOt9F5KO/G/1yH3YYdpDAnKhPw==",
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.76.0.tgz",
+      "integrity": "sha512-C+YZ5S5W9oTphdWTBgV+3nDdcV1ldnupIHylHzf2Co+xNtJ76V06N5NjdJ/l9+qvQjMn0DdSp7Uu7KCEeNBT/g==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.69.0",
-        "@sentry/core": "7.69.0",
-        "@sentry/types": "7.69.0",
-        "@sentry/utils": "7.69.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/tracing": "7.76.0",
+        "@sentry/core": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0",
+        "https-proxy-agent": "^5.0.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.69.0.tgz",
-      "integrity": "sha512-zPyCox0mzitzU6SIa1KIbNoJAInYDdUpdiA+PoUmMn2hFMH1llGU/cS7f4w/mAsssTlbtlBi72RMnWUCy578bw==",
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.76.0.tgz",
+      "integrity": "sha512-vj6z+EAbVrKAXmJPxSv/clpwS9QjPqzkraMFk2hIdE/kii8s8kwnkBwTSpIrNc8GnzV3qYC4r3qD+BXDxAGPaw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.69.0.tgz",
-      "integrity": "sha512-4eBixe5Y+0EGVU95R4NxH3jkkjtkE4/CmSZD4In8SCkWGSauogePtq6hyiLsZuP1QHdpPb9Kt0+zYiBb2LouBA==",
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.76.0.tgz",
+      "integrity": "sha512-40jFD+yfQaKpFYINghdhovzec4IEpB7aAuyH/GtE7E0gLpcqnC72r55krEIVILfqIR2Mlr5OKUzyeoCyWAU/yw==",
       "dependencies": {
-        "@sentry/types": "7.69.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.76.0"
       },
       "engines": {
         "node": ">=8"
@@ -3291,14 +3284,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -5678,11 +5663,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7962,11 +7942,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -78,11 +78,11 @@
   "author": "jonas.badalic@sentry.io",
   "license": "MIT",
   "dependencies": {
-    "@sentry/core": "^7.69.0",
-    "@sentry/hub": "^7.69.0",
-    "@sentry/node": "^7.69.0",
-    "@sentry/types": "^7.69.0",
-    "@sentry/utils": "^7.69.0",
+    "@sentry/core": "^7.76.0",
+    "@sentry/hub": "^7.76.0",
+    "@sentry/node": "^7.76.0",
+    "@sentry/types": "^7.76.0",
+    "@sentry/utils": "^7.76.0",
     "detect-libc": "^2.0.2",
     "node-abi": "^3.47.0",
     "node-gyp": "^9.4.0"


### PR DESCRIPTION
**Context**
I ran into a compiler error when trying to bump `@sentry/nextjs` to the latest version
> Type error: Type 'ProfilingIntegration' is not assignable to type 'Integration'.

By bumping the versions of all `@sentry` dependencies this repo will be up-to-date with the packages in the monorepo.

~~- [ ] If you've added code that should be tested, please add tests.~~
- [x] Ensure your code lints and the test suite passes.
