### PR TITLE
ref: close handle only if active

### DIFF
--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -111,6 +111,7 @@ class MeasurementsTicker {
 
     auto handle = reinterpret_cast<uv_handle_t *>(&timer);
 
+    // Calling uv_close on an inactive handle will cause a segfault.
     if (uv_is_active(handle)) {
       uv_close(handle, nullptr);
     }

--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -108,10 +108,10 @@ class MeasurementsTicker {
 
   ~MeasurementsTicker() {
     uv_timer_stop(&timer);
-    
+
     auto handle = reinterpret_cast<uv_handle_t *>(&timer);
 
-    if(uv_is_active(handle)) {
+    if (uv_is_active(handle)) {
       uv_close(handle, nullptr);
     }
   }

--- a/bindings/cpu_profiler.cc
+++ b/bindings/cpu_profiler.cc
@@ -108,7 +108,12 @@ class MeasurementsTicker {
 
   ~MeasurementsTicker() {
     uv_timer_stop(&timer);
-    uv_close(reinterpret_cast<uv_handle_t *>(&timer), nullptr);
+    
+    auto handle = reinterpret_cast<uv_handle_t *>(&timer);
+
+    if(uv_is_active(handle)) {
+      uv_close(handle, nullptr);
+    }
   }
 };
 


### PR DESCRIPTION
Having a bit of a hard time fixing this, though it seems like this occurs if we attempt to close an inactive handle. Added uv_is_active before calling close.

Fixes #233