### PR TITLE
fix: update types entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/getsentry/profiling-node.git"
   },
   "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "types": "lib/types/index.d.ts",
   "bin": {
     "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.mjs"
   },


### PR DESCRIPTION
After installing latest version of `@sentry/profiling-node` the types are not detected:
![CleanShot 2024-01-11 at 23 59 42](https://github.com/getsentry/profiling-node/assets/58401630/ba1fa228-644d-428d-bc32-a8c424a00193)

Seems like after recent changes `tsconfig.base.json` uses `outDir: lib/types`

![CleanShot 2024-01-12 at 00 00 53](https://github.com/getsentry/profiling-node/assets/58401630/1724c2b5-ea7f-4591-a0f2-a26248a920ac)

But `package.json` is not updated:
![CleanShot 2024-01-12 at 00 02 53](https://github.com/getsentry/profiling-node/assets/58401630/2796a74b-d273-4247-825f-b2f249090884)

